### PR TITLE
another place where we need to ensure 'fileopt' is not set for python.

### DIFF
--- a/run.py
+++ b/run.py
@@ -580,7 +580,8 @@ def process_model_worker(leaf, language, model):
     except KeyError:
         plot_options = {}
     plot_options['filename'] = leaf['id']
-    plot_options['fileopt'] = 'overwrite'
+    if language != 'python':
+        plot_options['fileopt'] = 'overwrite'
     data = {'json_figure': model,
             'pretty': True,
             'plot_options': plot_options}


### PR DESCRIPTION
fixing another place where fileopt is accidentally set for python (where it's not required to do so)
