### PR TITLE
builtin json! default with `indent` option adds trailing whitespace!

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -371,7 +371,7 @@ def write_language_reference(reference, language):
     if reference:
         ordered_referece = get_ordered_dict_with_lists(reference)
         with open(ref_file, 'w') as f:
-            json.dump(ordered_referece, f, indent=2)
+            json.dump(ordered_referece, f, indent=2, separators=(',', ': '))
     if not reference:
         print "\t\treference is empty, cuttin' this dead weight!"
         if os.path.exists(ref_file):
@@ -462,7 +462,7 @@ def save_tree(tree):
         pass
     sorted_new_tree = get_ordered_dict(tree)
     with open(files['tree'], 'w') as f:
-        json.dump(sorted_new_tree, f, indent=4)
+        json.dump(sorted_new_tree, f, indent=4, separators=(',', ': '))
 
 
 def get_ordered_dict(d):

--- a/run.py
+++ b/run.py
@@ -900,7 +900,7 @@ def save_tree(tree, previous_tree):
     new_tree = nested_merge(previous_tree, tree)
     sorted_new_tree = get_ordered_dict(new_tree)
     with open(files['tree'], 'w') as f:
-        json.dump(sorted_new_tree, f, indent=4)
+        json.dump(sorted_new_tree, f, indent=4, separators=(',', ': '))
 
 
 def save_processed_ids(processed_ids, previous_leaf_ids):
@@ -908,7 +908,7 @@ def save_processed_ids(processed_ids, previous_leaf_ids):
     ids = list(set.union(processed_ids, previous_leaf_ids))
     ids.sort()
     with open(files['ids'], 'w') as f:
-        json.dump(ids, f, indent=4)
+        json.dump(ids, f, indent=4, separators=(',', ': '))
 
 
 def nested_merge(old, update):


### PR DESCRIPTION
this is super annoying with git, but you can force it to act better!
