### PR TITLE
Dev mode!

### DIFF
--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -2,3 +2,4 @@ gems:
 - octopress-debugger
 
 staticurl: http://localhost:4000/all_static
+exclude: [_posts/ggplot2, _posts/julia, _posts/matlab, _posts/matplotlib, _posts/nodejs, _posts/plotly_js, _posts/python, _posts/r]

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,0 +1,4 @@
+gems:
+- octopress-debugger
+
+staticurl: http://localhost:4000/all_static


### PR DESCRIPTION
fyi @NicoleGrondin  -- this allows us to run and test locally and quickly!

if you want to develop locally, you can now run (in the `documentation` repo on the `gh-pages`)

```
$ jekyll serve --config _config_dev.yml
```

this will also ignore the bulk of the folders in `_posts` so that the compilation time is super speedy (~5 seconds). you can remove folder names in the `_config_dev.yml` file as you like if you want to test out specific pages.