### PR TITLE
Plotly finance html block

### DIFF
--- a/_includes/plotlyjs_html.html
+++ b/_includes/plotlyjs_html.html
@@ -1,11 +1,15 @@
-&lt;!DOCTYPE html&gt; 
+&lt;!DOCTYPE html&gt;
 &lt;head&gt;
   &lt;!-- D3.js --&gt;
   &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js"&gt;&lt;/script&gt;
-  &lt;!-- jQuery --&gt;  
+  &lt;!-- jQuery --&gt;
   &lt;script src="https://code.jquery.com/jquery-2.1.4.min.js"&gt;&lt;/script&gt;
-  &lt;!-- Plotly.js --&gt;   
+  &lt;!-- Plotly.js --&gt;
   &lt;script src="https://d14fo0winaifog.cloudfront.net/plotly-basic.js"&gt;&lt;/script&gt;
+  {% if page.permalink contains "candlestick-charts/" or page.permalink contains "ohlc-charts/" %}
+  &lt;!-- PlotlyFinance.js --&gt;
+  &lt;script src="https://cdn.rawgit.com/etpinard/plotlyjs-finance/master/plotlyjs-finance.js"&gt;&lt;/script&gt;
+  {% endif %}
 &lt;/head&gt;
 &lt;body&gt;
 &lt;!-- Plotly chart will be drawn inside this DIV --&gt;

--- a/all_static/css/modules.css
+++ b/all_static/css/modules.css
@@ -978,7 +978,7 @@ PLOTLY.JS VERSION NUMBER
 ************************/
 .version-number{
   margin-top: 10px;
-      color: white;
+      color: grey;
       opacity: 0.6;
 }
 

--- a/all_static/css/modules.css
+++ b/all_static/css/modules.css
@@ -990,6 +990,14 @@ PLOTLY.JS VERSION NUMBER
   margin: 0px 30px;
 }
 
+@media (max-width: 700px){
+  .plotlyjs-download{
+    padding: 5px 0px;
+    margin: 0px 0px;
+    min-width: 98%;
+  }
+}
+
 /***************************
 SYNTAX HIGHLIGHTER OVERRIDES
 ***************************/


### PR DESCRIPTION
* Added plotly finance to html block on candlestick and ohlc examples
* Increased visibility of Plotly_js version number
* Made the download plotly_js button responsive (it was breaking the layout)