### PR TITLE
remove xlsx url due to grid issue

### DIFF
--- a/javascript/open-source-announcement/index.html
+++ b/javascript/open-source-announcement/index.html
@@ -332,7 +332,6 @@
 <li>plotly.js code: <a href="https://plot.ly/%7Eempet/6640.js">https://plot.ly/~empet/6640.json</a></li>
 <li>Raster image: <a href="https://plot.ly/%7Eempet/6640.png">https://plot.ly/~empet/6640.png</a></li>
 <li>Vector image: <a href="https://plot.ly/%7Eempet/6640.svg">https://plot.ly/~empet/6640.svg</a></li>
-<li>Excel: <a href="https://plot.ly/%7Eempet/6640.xlsx">https://plot.ly/~empet/6640.xlsx</a></li>
 <li>Python code: <a href="https://plot.ly/%7Eempet/6640.py">https://plot.ly/~empet/6640.py</a></li>
 <li>CSV data: <a href="https://plot.ly/%7Eempet/6640.csv">https://plot.ly/~empet/6640.csv</a></li>
 </ul>


### PR DESCRIPTION
ping @chriddyp @theengineear removing xlsx url for now due to grid issue reported by user: `empet`.