### PR TITLE
Events docs update

### DIFF
--- a/_posts/2015-04-05-plotlyjs-function-reference.md
+++ b/_posts/2015-04-05-plotlyjs-function-reference.md
@@ -23,6 +23,7 @@ redirect_from: /javascript-graphing-library/plotlyjs-function-reference
               <li><a href="#plotly-deletetraces" class="attribute-name"><p class="left-align">Delete traces with Plotly.deleteTraces</p></a></li>
               <li><a href="#plotly-movetraces" class="attribute-name"><p class="left-align">Move traces with Plotly.moveTraces</p></a></li>
               <li><a href="#plotly-redraw" class="attribute-name"><p class="left-align">Redraw with Plotly.redraw</p></a></li>
+              <li><a href="#plotly-events" class="attribute-name"><p class="left-align">Using events</p></a></li>
           </ul>
       </div>
     </div>
@@ -92,8 +93,9 @@ Plotly.newPlot(graphDiv, data2, layout2);
 </code></pre>
 <br>
 
-<iframe height='518' scrolling='no' src='//codepen.io/plotly/embed/meaKwE/?height=518&theme-id=15263&default-tab=result' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>See the Pen <a href='http://codepen.io/plotly/pen/meaKwE/'>Plotly.newPlot</a> by Plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.
-</iframe>
+<p data-height="440" data-theme-id="15263" data-slug-hash="meaKwE" data-default-tab="result" data-user="plotly" class='codepen' data-preview="true">See the Pen <a href='http://codepen.io/plotly/pen/meaKwE/'>Plotly.newPlot</a> by plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.</p>
+<script async src="//assets.codepen.io/assets/embed/ei.js"></script>
+
 <br>
 
 You can hide the link to Plotly's cloud with <code>{showLink: false}</code> as the 4th argument.<br>
@@ -130,8 +132,10 @@ Plotly.restyle(graphDiv, update, [1, 2]);
 
 <br>
 
-<iframe height='510' scrolling='no' src='//codepen.io/plotly/embed/meaKYw/?height=510&theme-id=15263&default-tab=result' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>See the Pen <a href='http://codepen.io/plotly/pen/meaKYw/'>Plotly.restyle</a> by Plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.
-</iframe>
+<p data-height="400" data-theme-id="15263" data-slug-hash="meaKYw" data-default-tab="result" data-user="plotly" class='codepen' data-preview="true">See the Pen <a href='http://codepen.io/plotly/pen/meaKYw/'>Plotly.restyle</a> by plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.</p>
+<script async src="//assets.codepen.io/assets/embed/ei.js"></script>
+
+<br>
 
 The above examples have applied values across single or multiple traces. However, you can also specify <b>arrays</b> of values to apply to traces <b>in turn</b>.
 
@@ -151,8 +155,7 @@ Plotly.restyle(graphDiv, update)
 
 <br>
 
-<iframe height='515' scrolling='no' src='//codepen.io/plotly/embed/NGeBGL/?height=515&theme-id=15263&default-tab=result' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>See the Pen <a href='http://codepen.io/plotly/pen/NGeBGL/'>Plotly.restyle Traces in Turn</a> by Plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.
-</iframe>
+<p data-height="515" data-theme-id="15263" data-slug-hash="NGeBGL" data-default-tab="result" data-user="plotly" class='codepen' data-preview="true">See the Pen <a href='http://codepen.io/plotly/pen/NGeBGL/'>Plotly.restyle Traces in Turn</a> by plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.</p>
 
 <br>
 
@@ -173,8 +176,8 @@ Plotly.restyle(graphDiv, update, [1, 2])
 
 <br>
 
-<iframe height='502' scrolling='no' src='//codepen.io/plotly/embed/wKRxJE/?height=502&theme-id=15263&default-tab=result' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>See the Pen <a href='http://codepen.io/plotly/pen/wKRxJE/'>Plotly.restyle Arrays </a> by Plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.
-</iframe>
+<p data-height="502" data-theme-id="15263" data-slug-hash="wKRxJE" data-default-tab="result" data-user="plotly" class='codepen' data-preview="true">See the Pen <a href='http://codepen.io/plotly/pen/wKRxJE/'>Plotly.restyle Arrays </a> by plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.</p>
+<script async src="//assets.codepen.io/assets/embed/ei.js"></script>
 
 <br>
 
@@ -190,8 +193,8 @@ Plotly.restyle(graphDiv, update, [0])
 
 <br>
 
-<iframe height='528' scrolling='no' src='//codepen.io/plotly/embed/LpMBOy/?height=528&theme-id=15263&default-tab=result' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>See the Pen <a href='http://codepen.io/plotly/pen/LpMBOy/'>Plotly.restyle Attribute strings </a> by Plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.
-</iframe>
+<p data-height="528" data-theme-id="15263" data-slug-hash="LpMBOy" data-default-tab="result" data-user="plotly" class='codepen' data-preview="true">See the Pen <a href='http://codepen.io/plotly/pen/LpMBOy/'>Plotly.restyle Attribute strings </a> by plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.</p>
+<script async src="//assets.codepen.io/assets/embed/ei.js"></script>
 
 <br>
 
@@ -210,8 +213,8 @@ Plotly.relayout(graphDiv, update)
 
 <br>
 
-<iframe height='526' scrolling='no' src='//codepen.io/plotly/embed/meajqx/?height=526&theme-id=15263&default-tab=result' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>See the Pen <a href='http://codepen.io/plotly/pen/meajqx/'>Plotly.relayout</a> by Plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.
-</iframe>
+<p data-height="526" data-theme-id="15263" data-slug-hash="meajqx" data-default-tab="result" data-user="plotly" class='codepen' data-preview="true">See the Pen <a href='http://codepen.io/plotly/pen/meajqx/'>Plotly.relayout</a> by plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.</p>
+<script async src="//assets.codepen.io/assets/embed/ei.js"></script>
 
 <br>
 
@@ -228,8 +231,8 @@ Plotly.relayout(graphDiv, update)
 
 <br>
 
-<iframe height='507' scrolling='no' src='//codepen.io/plotly/embed/jbXpZj/?height=507&theme-id=15263&default-tab=result' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>See the Pen <a href='http://codepen.io/plotly/pen/jbXpZj/'>Plotly.relayout - xaxis replace</a> by Plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.
-</iframe>
+<p data-height="507" data-theme-id="15263" data-slug-hash="jbXpZj" data-default-tab="result" data-user="plotly" class='codepen' data-preview="true">See the Pen <a href='http://codepen.io/plotly/pen/jbXpZj/'>Plotly.relayout - xaxis replace</a> by plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.</p>
+<script async src="//assets.codepen.io/assets/embed/ei.js"></script>
 
 <br>
 
@@ -250,8 +253,8 @@ Plotly.addTraces(graphDiv, {y: [1, 5, 7]}, 0);
 
 <br>
 
-<iframe height='510' scrolling='no' src='//codepen.io/plotly/embed/xwmJvL/?height=510&theme-id=15263&default-tab=result' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>See the Pen <a href='http://codepen.io/plotly/pen/xwmJvL/'>Plotly.addtraces</a> by Plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.
-</iframe>
+<p data-height="510" data-theme-id="15263" data-slug-hash="xwmJvL" data-default-tab="result" data-user="plotly" class='codepen' data-preview="true">See the Pen <a href='http://codepen.io/plotly/pen/xwmJvL/'>Plotly.addtraces</a> by plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.</p>
+<script async src="//assets.codepen.io/assets/embed/ei.js"></script>
 
 <br>
 
@@ -269,8 +272,8 @@ Plotly.deleteTraces(graphDiv, [-2, -1]);
 
 <br>
 
-<iframe height='503' scrolling='no' src='//codepen.io/plotly/embed/meaGRo/?height=503&theme-id=15263&default-tab=result' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>See the Pen <a href='http://codepen.io/plotly/pen/meaGRo/'>Plotly.deleteTraces</a> by Plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.
-</iframe>
+<p data-height="503" data-theme-id="15263" data-slug-hash="meaGRo" data-default-tab="result" data-user="plotly" class='codepen' data-preview="true">See the Pen <a href='http://codepen.io/plotly/pen/meaGRo/'>Plotly.deleteTraces</a> by plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.</p>
+<script async src="//assets.codepen.io/assets/embed/ei.js"></script>
 
 <br>
 
@@ -294,8 +297,8 @@ Plotly.moveTraces(graphDiv, [1, 4, 5], [0, 3, 2]);
 
 <br>
 
-<iframe height='500' scrolling='no' src='//codepen.io/plotly/embed/LpMJyB/?height=500&theme-id=15263&default-tab=result' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>See the Pen <a href='http://codepen.io/plotly/pen/LpMJyB/'>Plotly.moveTraces</a> by Plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.
-</iframe>
+<p data-height="500" data-theme-id="15263" data-slug-hash="LpMJyB" data-default-tab="result" data-user="plotly" class='codepen' data-preview="true">See the Pen <a href='http://codepen.io/plotly/pen/LpMJyB/'>Plotly.moveTraces</a> by plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.</p>
+<script async src="//assets.codepen.io/assets/embed/ei.js"></script>
 
 <br>
 
@@ -317,8 +320,25 @@ Plotly.redraw(graphDiv);
 
 <br>
 
-<iframe height='515' scrolling='no' src='//codepen.io/plotly/embed/GpPXdV/?height=515&theme-id=15263&default-tab=result' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>See the Pen <a href='http://codepen.io/plotly/pen/GpPXdV/'>Plotly.redraw</a> by Plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.
-</iframe>
+<p data-height="515" data-theme-id="15263" data-slug-hash="GpPXdV" data-default-tab="result" data-user="plotly" class='codepen' data-preview="true">See the Pen <a href='http://codepen.io/plotly/pen/GpPXdV/'>Plotly.redraw</a> by plotly (<a href='http://codepen.io/plotly'>@plotly</a>) on <a href='http://codepen.io'>CodePen</a>.</p>
+<script async src="//assets.codepen.io/assets/embed/ei.js"></script>
+
+<br>
+
+<h4 id="plotly-events"><a class="no_underline plot-blue" href="#plotly-redraw">Using events</a></h4>
+
+Plots emit events prefixed with <code>plotly_</code> when clicked or hovered over, and event handlers can be bound to events using the <code>on</code> method that is exposed by the plot div object. It is possible to use jQuery events, but plotly.js no longer bundles jQuery, so we recommend using the plotly.js implementation.
+
+<pre><code class="language-javascript hljs" data-lang="javascript">
+// You can obtain the plot using document.getElementById('graphDiv')
+graphDiv.on('plotly_click', function(data){
+    // do something using the event data
+});
+</code></pre>
+
+<br>
+
+As well as <code>plotly\_click</code>, there is <code>plotly\_hover</code> and <code>plotly_unhover</code>.
 
 <br>
 

--- a/_posts/2015-04-05-plotlyjs-function-reference.md
+++ b/_posts/2015-04-05-plotlyjs-function-reference.md
@@ -338,7 +338,7 @@ graphDiv.on('plotly_click', function(data){
 
 <br>
 
-As well as <code>plotly\_click</code>, there is <code>plotly\_hover</code> and <code>plotly_unhover</code>.
+As well as <code>plotly\_click</code>, there is <code>plotly\_beforehover</code>, <code>plotly\_hover</code> and <code>plotly_unhover</code>.
 
 <br>
 

--- a/_posts/plotly_js/callbacks-click/2015-04-09-click-annotation.html
+++ b/_posts/plotly_js/callbacks-click/2015-04-09-click-annotation.html
@@ -5,7 +5,6 @@ language: plotly_js
 suite: click-events
 sitemap: false
 height: 650
-arrangement: horizontal
 order: 1
 ---
 <p>Create or remove an annotation when clicking on a point.</p>

--- a/_posts/plotly_js/callbacks-click/2015-04-09-click.html
+++ b/_posts/plotly_js/callbacks-click/2015-04-09-click.html
@@ -18,12 +18,13 @@ var N = 16,
 
 Plotly.newPlot('myDiv', data, layout);
 
-$('#myDiv').bind('plotly_click',
-    function(event,data){
-        var pts = '';
-        for(var i=0; i&lt;data.points.length; i++){
-            pts = 'x = '+data.points[i].x +'\ny = '+
-                data.points[i].y.toPrecision(4) + '\n\n';
-        }
+myPlot = document.getElementById('myDiv');
+
+myPlot.on('plotly_click', function(data){
+    var pts = '';
+    for(var i=0; i&lt;data.points.length; i++){
+        pts = 'x = '+data.points[i].x +'\ny = '+
+            data.points[i].y.toPrecision(4) + '\n\n';
+    }
     alert('Closest point clicked:\n\n'+pts);
 });

--- a/_posts/plotly_js/callbacks-click/2015-04-09-click.html
+++ b/_posts/plotly_js/callbacks-click/2015-04-09-click.html
@@ -6,7 +6,8 @@ suite: click-events
 sitemap: false
 order: 0
 ---
-var N = 16,
+var myPlot = document.getElementById('myDiv'),
+    N = 16,
     x = d3.range(N),
     y = d3.range(N).map( d3.random.normal() ),
     data = [ { x:x, y:y, type:'scatter',
@@ -17,8 +18,6 @@ var N = 16,
      };
 
 Plotly.newPlot('myDiv', data, layout);
-
-myPlot = document.getElementById('myDiv');
 
 myPlot.on('plotly_click', function(data){
     var pts = '';

--- a/_posts/plotly_js/callbacks-hover/2015-04-09-hover-bind.html
+++ b/_posts/plotly_js/callbacks-hover/2015-04-09-hover-bind.html
@@ -6,7 +6,9 @@ suite: hover-events
 sitemap: false
 order: 0
 ---
-var N = 16,
+var myPlot = document.getElementById('myDiv'),
+    hoverInfo = document.getElementById('hoverinfo'),
+    N = 16,
     x = d3.range(N),
     y1 = d3.range(N).map( d3.random.normal() ),
     y2 = d3.range(N).map( d3.random.normal() ),
@@ -19,15 +21,15 @@ var N = 16,
         title:'Hover on Points'
      };
 
-Plotly.newPlot('myDiv', data, layout);
+Plotly.plot('myDiv', data, layout);
 
-$('#myDiv')
-    .bind('plotly_hover', function(event,data){
-        var infotext = data.points.map(function(d){
-            return (d.data.name+': x= '+d.x+', y= '+d.y.toPrecision(3));
-        });
-        $('#hoverinfo').html(infotext.join('<br/>'));
-    })
-    .bind('plotly_unhover', function(event,data){
-        $('#hoverinfo').html('');
+myPlot.on('plotly_hover', function(data){
+    var infotext = data.points.map(function(d){
+      return (d.data.name+': x= '+d.x+', y= '+d.y.toPrecision(3));
     });
+  
+    hoverInfo.innerHTML = infotext.join('<br/>');
+})
+ .on('plotly_unhover', function(data){
+    hoverInfo.innerHTML = '';
+});

--- a/_posts/plotly_js/callbacks-hover/2015-04-09-hover-coupling.html
+++ b/_posts/plotly_js/callbacks-hover/2015-04-09-hover-coupling.html
@@ -6,7 +6,7 @@ suite: hover-events
 sitemap: false
 arrangement: horizontal
 height: 775
-order: 3
+order: 4
 ---
 <div>
 <p>Hover in one graph triggers a hover event in 3 other graphs.</p>

--- a/_posts/plotly_js/callbacks-hover/2015-04-09-hover-manual.html
+++ b/_posts/plotly_js/callbacks-hover/2015-04-09-hover-manual.html
@@ -6,7 +6,9 @@ suite: hover-events
 sitemap: false
 order: 1
 ---
-var N = 16,
+var myPlot = document.getElementById('myDiv'),
+    hoverButton = document.getElementById('hoverbutton'),
+    N = 16,
     x = d3.range(N),
     y1 = d3.range(N).map( d3.random.normal() ),
     y2 = d3.range(N).map( d3.random.normal() ),
@@ -16,15 +18,16 @@ var N = 16,
         mode:'markers', marker:{size:16} } ];
     layout = { 
         hovermode:'closest',
-        title:'Hover on Points'
+        title:'Click "Go" button to trigger hover'
      };
 
-Plotly.newPlot('myDiv', data, layout);
+Plotly.plot('myDiv', data, layout);
 
-$('#myDiv')
-    .bind('plotly_beforehover',function(){return false; })
+myPlot.on('plotly_beforehover',function(){ 
+    return false; 
+});
 
-$('#hoverbutton button').click(function(){
+hoverButton.addEventListener('click', function(){
     var curve1 = Math.floor(Math.random()*2),
         curve2 = Math.floor(Math.random()*2),
         point1 = Math.floor(Math.random()*14),

--- a/_posts/plotly_js/callbacks-hover/2015-10-08-hover-coupled.html
+++ b/_posts/plotly_js/callbacks-hover/2015-10-08-hover-coupled.html
@@ -4,24 +4,25 @@ plot_url: https://codepen.io/plotly/embed/zvzdGb/?height=600&theme-id=15263&defa
 language: plotly_js
 suite: hover-events
 sitemap: false
-arrangement: horizontal
 order: 2
 ---
-var N = 12,
+var myPlot = document.getElementById('myDiv'),
+    N = 12,
     x1 = d3.range(N).map( d3.random.normal() ),
     x2 = d3.range(N).map( d3.random.normal() ),
     x3 = d3.range(N).map( d3.random.normal() ),
     y1 = d3.range(N).map( d3.random.normal() ),
     y2 = d3.range(N).map( d3.random.normal() ),
     y3 = d3.range(N).map( d3.random.normal() ),
-    months = ['January', 'February', 'March', 'April', 'May', 'June',
-              'July', 'August', 'September', 'October', 'November', 'December']
+    months = ['January', 'February', 'March', 'April', 
+              'May', 'June', 'July', 'August', 
+              'September', 'October', 'November', 'December']
     data = [{ x: x1, y: y1, text: months, type: 'scatter', name: '2014', hoverinfo: 'text+x+y',
               mode: 'markers', marker: {color: 'rgba(200, 50, 100, .7)', size: 16}
-             },
+            },
             { x: x2, y: y2, text: months, type: 'scatter', name: '2015', hoverinfo: 'text+x+y',
              mode: 'markers', marker: {color: 'rgba(120, 20, 130, .7)', size: 16}
-             },
+            },
             { x: x3, y: y3, text: months, type: 'scatter', name: '2016', hoverinfo: 'text+x+y',
              mode: 'markers', marker: {color: 'rgba(10, 180, 180, .8)', size: 16}
             }];
@@ -34,13 +35,13 @@ var N = 12,
 
 Plotly.newPlot('myDiv', data, layout);
 
-$('#myDiv')
-    .on('plotly_hover', function (event, eventdata){
-  var points = eventdata.points[0],
-      pointNum = points.pointNumber;
+myPlot.on('plotly_hover', function (eventdata){
+    var points = eventdata.points[0],
+        pointNum = points.pointNumber;
+
     Plotly.Fx.hover('myDiv',[
-      {curveNumber:0, pointNumber:pointNum},
-      {curveNumber:1, pointNumber:pointNum},
-      {curveNumber:2, pointNumber:pointNum},
-    ])
+        { curveNumber:0, pointNumber:pointNum },
+        { curveNumber:1, pointNumber:pointNum },
+        { curveNumber:2, pointNumber:pointNum },
+    ]);
 });

--- a/_posts/plotly_js/callbacks-hover/2015-12-02-hover-complex.html
+++ b/_posts/plotly_js/callbacks-hover/2015-12-02-hover-complex.html
@@ -1,6 +1,6 @@
 ---
 name: Combined Click and Hover Events
-plot_url: https://codepen.io/plotly/embed/eJOyej/?height=540&theme-id=15263&default-tab=result
+plot_url: https://codepen.io/plotly/embed/eJOyej/?height=520&theme-id=15263&default-tab=result
 language: plotly_js
 suite: hover-events
 sitemap: false
@@ -8,3 +8,5 @@ arrangement: horizontal
 height: 700
 order: 3
 ---
+
+This is a more complex example that uses both hover, and click events to display traces. Take a look in the codepen javascript!

--- a/_posts/plotly_js/callbacks-hover/2015-12-02-hover-complex.html
+++ b/_posts/plotly_js/callbacks-hover/2015-12-02-hover-complex.html
@@ -1,0 +1,10 @@
+---
+name: Combined Click and Hover Events
+plot_url: https://codepen.io/plotly/embed/eJOyej/?height=540&theme-id=15263&default-tab=result
+language: plotly_js
+suite: hover-events
+sitemap: false
+arrangement: horizontal
+height: 700
+order: 3
+---


### PR DESCRIPTION
Added in a brief explanation of the plotly events in the function reference section, as well as updated the code examples for click and hover to *not* use jQuery and use the `plot.on` way.