### PR TITLE
Fix broken links in Scala documentation.

### DIFF
--- a/_posts/scala/2016-03-22-getting-started.md
+++ b/_posts/scala/2016-03-22-getting-started.md
@@ -19,7 +19,7 @@ The Scala plotly client is updated frequently. Check that you include the [lates
 
 # API Documentation and source code
 
-If you need documentation beyond the tutorials presented here, read either the [Scaladocs](http://the-asi.github.io/scala-plotly-client/) for API documentation, or the [Source code](https://github.com/the-asi/scala-plotly-client).
+If you need documentation beyond the tutorials presented here, read either the [Scaladocs](http://asidatascience.github.io/scala-plotly-client/) for API documentation, or the [Source code](https://github.com/asidatascience/scala-plotly-client).
 
 # Initialization
 


### PR DESCRIPTION
Some of the links were broken because of the rebranding on ASI data science's Github repo. Now fixed.