### PR TITLE
Removing redundant and difficult to parse header descriptions

### DIFF
--- a/_posts/2016-06-03-plotly_js_function_ref.html
+++ b/_posts/2016-06-03-plotly_js_function_ref.html
@@ -10,7 +10,7 @@ redirect_from: /javascript-graphing-library/plotlyjs-function-reference
 
 <h1>plotly.js Function Reference</h1>
 
-<h4 id="retrieving-data-layout"><a class="no_underline plot-blue" href="#retrieving-data-layout">Retrieving the plot <code>data</code> or <code>layout</code></pre> objects</a></h4>
+<h4 id="retrieving-data-layout"><a class="no_underline plot-blue" href="#retrieving-data-layout">plotNode.data <code>and</code> plotNode.layout</a></h4>
 
 The plot <code>data</code> or <code>layout</code> can  be retrieved from the <code>&lt;div&gt;</code> element in which the plot was drawn:
 
@@ -22,7 +22,7 @@ var plotDiv = document.getElementById('examplePlot');
 var plotData = plotDiv.data;
 </code></pre>
 
-<h4 id="plotly-newplot"><a>Plot with <code>Plotly.newPlot</code></a></h4>
+<h4 id="plotly-newplot"><a>Plotly.newPlot</a></h4>
 
 Use <code>newPlot</code> to create a new plot in an empty <code>&lt;div&gt;</code> element.
 A note on sizing: You can either supply height and width in <code>layout</code>, or give <code>graphDiv</code> a height and width in css.
@@ -75,7 +75,7 @@ You can hide the link to Plotly's cloud with <code>{showLink: false}</code> as t
 
 There are several other options that you can supply as the fourth argument. See more examples of the <a href="https://plot.ly/javascript/configuration-options/">configuration options.</a>
 
-<h4 id="plotly-restyle"><a class="no_underline plot-blue" href="#plotly-restyle">Edit attributes with <code>Plotly.restyle</code></a></h4>
+<h4 id="plotly-restyle"><a class="no_underline plot-blue" href="#plotly-restyle">Plotly.restyle</a></h4>
 
 A more efficient means of changing parameters in the data array. When restyling, you may choose to have the specified changes effect as many traces as desired. The update is given as a single object and the traces that are effected are given as a list of traces indices. Note, leaving the trace indices unspecified assumes that you want to restyle <b>all</b> the traces.
 
@@ -170,7 +170,7 @@ Plotly.restyle(graphDiv, update, [0])
 
 <br>
 
-<h4 id="plotly-relayout"><a class="no_underline plot-blue" href="#plotly-relayout">Update layout attributes with <code>Plotly.relayout</code></a></h4>
+<h4 id="plotly-relayout"><a class="no_underline plot-blue" href="#plotly-relayout">Plotly.relayout</a></h4>
 
 A more efficient means of updating just the layout in a graphDiv. The call signature and arguments for relayout are similar (but simpler) to restyle. Because there are no indices to deal with, arrays need not be wrapped. Also, no argument specifying applicable trace indices is passed in.
 
@@ -208,7 +208,7 @@ Plotly.relayout(graphDiv, update)
 
 <br>
 
-<h4 id="plotly-addtraces"><a class="no_underline plot-blue" href="#plotly-addtraces">Add Traces with <code>Plotly.addTraces</code></a></h4>
+<h4 id="plotly-addtraces"><a class="no_underline plot-blue" href="#plotly-addtraces">Plotly.addTraces</a></h4>
 
 This allows you to add <b>new</b> traces to an existing <code>graphDiv</code> at any location in its data array.
 
@@ -230,7 +230,7 @@ Plotly.addTraces(graphDiv, {y: [1, 5, 7]}, 0);
 
 <br>
 
-<h4 id="plotly-deletetraces"><a class="no_underline plot-blue" href="#plotly-deletetraces">Delete Traces with <code>Plotly.deleteTraces</code></a></h4>
+<h4 id="plotly-deletetraces"><a class="no_underline plot-blue" href="#plotly-deletetraces">Plotly.deleteTraces</a></h4>
 
 This allows you to remove traces from an existing <code>graphDiv</code> by specifying the indices of the traces to be removed.
 

--- a/_posts/2016-06-03-plotly_js_function_ref.html
+++ b/_posts/2016-06-03-plotly_js_function_ref.html
@@ -10,7 +10,7 @@ redirect_from: /javascript-graphing-library/plotlyjs-function-reference
 
 <h1>plotly.js Function Reference</h1>
 
-<h4 id="retrieving-data-layout"><a class="no_underline plot-blue" href="#retrieving-data-layout">plotNode.data <code>and</code> plotNode.layout</a></h4>
+<h4 id="retrieving-data-layout"><a class="no_underline plot-blue" href="#retrieving-data-layout">plotDiv.data and plotDiv.layout</a></h4>
 
 The plot <code>data</code> or <code>layout</code> can  be retrieved from the <code>&lt;div&gt;</code> element in which the plot was drawn:
 

--- a/_posts/2016-06-03-plotly_js_function_ref.html
+++ b/_posts/2016-06-03-plotly_js_function_ref.html
@@ -77,7 +77,7 @@ There are several other options that you can supply as the fourth argument. See 
 
 <h4 id="plotly-restyle"><a class="no_underline plot-blue" href="#plotly-restyle">Plotly.restyle</a></h4>
 
-A more efficient means of changing parameters in the data array. When restyling, you may choose to have the specified changes effect as many traces as desired. The update is given as a single object and the traces that are effected are given as a list of traces indices. Note, leaving the trace indices unspecified assumes that you want to restyle <b>all</b> the traces.
+A more efficient means of changing attributes in the data array. When restyling, you may choose to have the specified changes effect as many traces as desired. The update is given as a single object and the traces that are effected are given as a list of traces indices. Note, leaving the trace indices unspecified assumes that you want to restyle <b>all</b> the traces.
 
 <pre><code class="language-javascript hljs" data-lang="javascript">
 // restyle a single trace using attribute strings


### PR DESCRIPTION
The "DO THIS WITH plotly.whatever" looks terrible. Removing the redundant "DO THIS WITH" part and removing the html code nodes so that the function names are properly front and center.