### PR TITLE
Fix typo in animation docs

### DIFF
--- a/_posts/plotly_js/animations/2016-09-15-animations-animating-the-data.html
+++ b/_posts/plotly_js/animations/2016-09-15-animations-animating-the-data.html
@@ -25,7 +25,7 @@ function randomize() {
   }, {
     transition: {
       duration: 500,
-      ease: 'cubic-in-out'
+      easing: 'cubic-in-out'
     }
   })
 }


### PR DESCRIPTION
This PR fixes a tiny typo in the animation docs.