### PR TITLE
added settings section and tutorial for increasing size of dashboard

### DIFF
--- a/_posts/python/fundamentals/dashboard/2015-06-30-dashboard-api.html
+++ b/_posts/python/fundamentals/dashboard/2015-06-30-dashboard-api.html
@@ -60,7 +60,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version</p>
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>&#39;2.0.5&#39;</pre>
+<pre>&#39;2.0.6&#39;</pre>
 </div>
 
 </div>
@@ -831,6 +831,184 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version</p>
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
+<h4 id="Other-Settings-Options">Other Settings Options<a class="anchor-link" href="#Other-Settings-Options">&#182;</a></h4><p>You can adjust other colors of the dashboard too:</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[33]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;backgroundColor&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;#FFFFFF&#39;</span>
+<span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;headerForegroundColor&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;#FFFFFF&#39;</span>
+<span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;boxBackgroundColor&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;#FFFFFF&#39;</span>
+<span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;boxBorderColor&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;#FFFFFF&#39;</span>
+<span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;boxHeaderBackgroundColor&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;#FFFFFF&#39;</span>
+<span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;foregroundColor&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;#FFFFFF&#39;</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered">
+<div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h4 id="Relayout-the-Dashboard-Sizes">Relayout the Dashboard Sizes<a class="anchor-link" href="#Relayout-the-Dashboard-Sizes">&#182;</a></h4><p>Right now there is no native way to adjust the sizes of the dashboard boxes. A current issue with stacking boxes in a dashhboard layout is that each added box gets incrementally half as big as the one before it after inserting into the dashboard.</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[46]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">stacked_dboard</span> <span class="o">=</span> <span class="n">dashboard</span><span class="o">.</span><span class="n">Dashboard</span><span class="p">()</span>
+<span class="n">text_box</span> <span class="o">=</span> <span class="p">{</span>
+    <span class="s1">&#39;type&#39;</span><span class="p">:</span> <span class="s1">&#39;box&#39;</span><span class="p">,</span>
+    <span class="s1">&#39;boxType&#39;</span><span class="p">:</span> <span class="s1">&#39;text&#39;</span><span class="p">,</span>
+    <span class="s1">&#39;text&#39;</span><span class="p">:</span> <span class="s1">&#39;empty space&#39;</span> 
+<span class="p">}</span>
+<span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="mi">5</span><span class="p">):</span>
+    <span class="n">stacked_dboard</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">text_box</span><span class="p">,</span> <span class="s1">&#39;below&#39;</span><span class="p">,</span> <span class="mi">1</span><span class="p">)</span>
+<span class="n">stacked_dboard</span><span class="o">.</span><span class="n">get_preview</span><span class="p">()</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+<div class="prompt output_prompt">Out[46]:</div>
+
+
+<div class="output_html rendered_html output_subarea output_execute_result">
+
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0px;
+        padding: 0px;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="myCanvas" width="400" height="400"></canvas>
+    <script>
+      var canvas = document.getElementById('myCanvas');
+      var context = canvas.getContext('2d');
+      <!-- Dashboard -->
+      context.beginPath();
+      context.rect(0, 0, 400, 400);
+      context.lineWidth = 2;
+      context.strokeStyle = 'black';
+      context.stroke();
+     <!-- Draw some lines in -->
+          context.beginPath();
+          context.rect(0, 200, 400, 1);
+          context.lineWidth = 1;
+          context.strokeStyle = 'black';
+          context.stroke();
+    <!-- Draw some lines in -->
+          context.beginPath();
+          context.rect(0, 300, 400, 1);
+          context.lineWidth = 1;
+          context.strokeStyle = 'black';
+          context.stroke();
+    <!-- Insert box numbers -->
+          context.font = '10pt Times New Roman';
+          context.textAlign = 'center';
+          context.fillText(5, 0 + 0.5*400, 0 + 0.5*200);
+    <!-- Draw some lines in -->
+          context.beginPath();
+          context.rect(0, 350, 400, 1);
+          context.lineWidth = 1;
+          context.strokeStyle = 'black';
+          context.stroke();
+    <!-- Insert box numbers -->
+          context.font = '10pt Times New Roman';
+          context.textAlign = 'center';
+          context.fillText(4, 0 + 0.5*400, 200 + 0.5*100);
+    <!-- Draw some lines in -->
+          context.beginPath();
+          context.rect(0, 375, 400, 1);
+          context.lineWidth = 1;
+          context.strokeStyle = 'black';
+          context.stroke();
+    <!-- Insert box numbers -->
+          context.font = '10pt Times New Roman';
+          context.textAlign = 'center';
+          context.fillText(3, 0 + 0.5*400, 300 + 0.5*50);
+    <!-- Insert box numbers -->
+          context.font = '10pt Times New Roman';
+          context.textAlign = 'center';
+          context.fillText(1, 0 + 0.5*400, 375 + 0.5*25);
+    <!-- Insert box numbers -->
+          context.font = '10pt Times New Roman';
+          context.textAlign = 'center';
+          context.fillText(2, 0 + 0.5*400, 350 + 0.5*25);
+     </script>
+  </body>
+</html>
+
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered">
+<div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>If a dashboard looks like the one above, it may be difficult to grab the handlebars when it is being editted in the <a href="https://plot.ly/dashboard/create/">online creator</a>. To avoid this issue, resize the dashboard:</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[49]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">stacked_dboard</span><span class="p">[</span><span class="s1">&#39;layout&#39;</span><span class="p">][</span><span class="s1">&#39;size&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="mi">3000</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered">
+<div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>COMING SOON: A manual way to change the sizes of the boxes in a dashboard using the Dashboard API.</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered">
+<div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
 <h4 id="Upload-Dashboard">Upload Dashboard<a class="anchor-link" href="#Upload-Dashboard">&#182;</a></h4><p>To upload your dashboard to your <a href="https://plot.ly/organize/home/">Plotly cloud account</a> use <code>py.dashboard_ops.upload()</code>.</p>
 
 </div>
@@ -838,7 +1016,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version</p>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[22]:</div>
+<div class="prompt input_prompt">In&nbsp;[23]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">plotly.plotly</span> <span class="kn">as</span> <span class="nn">py</span>
@@ -854,7 +1032,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version</p>
 
 
 <div class="output_area">
-<div class="prompt output_prompt">Out[22]:</div>
+<div class="prompt output_prompt">Out[23]:</div>
 
 
 
@@ -900,7 +1078,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version</p>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[23]:</div>
+<div class="prompt input_prompt">In&nbsp;[24]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">py</span><span class="o">.</span><span class="n">dashboard_ops</span><span class="o">.</span><span class="n">get_dashboard_names</span><span class="p">()</span>
@@ -915,7 +1093,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version</p>
 
 
 <div class="output_area">
-<div class="prompt output_prompt">Out[23]:</div>
+<div class="prompt output_prompt">Out[24]:</div>
 
 
 
@@ -931,7 +1109,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version</p>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[24]:</div>
+<div class="prompt input_prompt">In&nbsp;[25]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">recent_dboard</span> <span class="o">=</span> <span class="n">py</span><span class="o">.</span><span class="n">dashboard_ops</span><span class="o">.</span><span class="n">get_dashboard</span><span class="p">(</span><span class="s1">&#39;My First Dashboard with Python&#39;</span><span class="p">)</span>

--- a/_posts/python/fundamentals/dashboard/dashboard-api.ipynb
+++ b/_posts/python/fundamentals/dashboard/dashboard-api.ipynb
@@ -37,7 +37,7 @@
     {
      "data": {
       "text/plain": [
-       "'2.0.5'"
+       "'2.0.6'"
       ]
      },
      "execution_count": 1,
@@ -784,6 +784,164 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Other Settings Options\n",
+    "You can adjust other colors of the dashboard too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "my_dboard['settings']['backgroundColor'] = '#FFFFFF'\n",
+    "my_dboard['settings']['headerForegroundColor'] = '#FFFFFF'\n",
+    "my_dboard['settings']['boxBackgroundColor'] = '#FFFFFF'\n",
+    "my_dboard['settings']['boxBorderColor'] = '#FFFFFF'\n",
+    "my_dboard['settings']['boxHeaderBackgroundColor'] = '#FFFFFF'\n",
+    "my_dboard['settings']['foregroundColor'] = '#FFFFFF'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Relayout the Dashboard Sizes\n",
+    "Right now there is no native way to adjust the sizes of the dashboard boxes. A current issue with stacking boxes in a dashhboard layout is that each added box gets incrementally half as big as the one before it after inserting into the dashboard."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<!DOCTYPE HTML>\n",
+       "<html>\n",
+       "  <head>\n",
+       "    <style>\n",
+       "      body {\n",
+       "        margin: 0px;\n",
+       "        padding: 0px;\n",
+       "      }\n",
+       "    </style>\n",
+       "  </head>\n",
+       "  <body>\n",
+       "    <canvas id=\"myCanvas\" width=\"400\" height=\"400\"></canvas>\n",
+       "    <script>\n",
+       "      var canvas = document.getElementById('myCanvas');\n",
+       "      var context = canvas.getContext('2d');\n",
+       "      <!-- Dashboard -->\n",
+       "      context.beginPath();\n",
+       "      context.rect(0, 0, 400, 400);\n",
+       "      context.lineWidth = 2;\n",
+       "      context.strokeStyle = 'black';\n",
+       "      context.stroke();\n",
+       "     <!-- Draw some lines in -->\n",
+       "          context.beginPath();\n",
+       "          context.rect(0, 200, 400, 1);\n",
+       "          context.lineWidth = 1;\n",
+       "          context.strokeStyle = 'black';\n",
+       "          context.stroke();\n",
+       "    <!-- Draw some lines in -->\n",
+       "          context.beginPath();\n",
+       "          context.rect(0, 300, 400, 1);\n",
+       "          context.lineWidth = 1;\n",
+       "          context.strokeStyle = 'black';\n",
+       "          context.stroke();\n",
+       "    <!-- Insert box numbers -->\n",
+       "          context.font = '10pt Times New Roman';\n",
+       "          context.textAlign = 'center';\n",
+       "          context.fillText(5, 0 + 0.5*400, 0 + 0.5*200);\n",
+       "    <!-- Draw some lines in -->\n",
+       "          context.beginPath();\n",
+       "          context.rect(0, 350, 400, 1);\n",
+       "          context.lineWidth = 1;\n",
+       "          context.strokeStyle = 'black';\n",
+       "          context.stroke();\n",
+       "    <!-- Insert box numbers -->\n",
+       "          context.font = '10pt Times New Roman';\n",
+       "          context.textAlign = 'center';\n",
+       "          context.fillText(4, 0 + 0.5*400, 200 + 0.5*100);\n",
+       "    <!-- Draw some lines in -->\n",
+       "          context.beginPath();\n",
+       "          context.rect(0, 375, 400, 1);\n",
+       "          context.lineWidth = 1;\n",
+       "          context.strokeStyle = 'black';\n",
+       "          context.stroke();\n",
+       "    <!-- Insert box numbers -->\n",
+       "          context.font = '10pt Times New Roman';\n",
+       "          context.textAlign = 'center';\n",
+       "          context.fillText(3, 0 + 0.5*400, 300 + 0.5*50);\n",
+       "    <!-- Insert box numbers -->\n",
+       "          context.font = '10pt Times New Roman';\n",
+       "          context.textAlign = 'center';\n",
+       "          context.fillText(1, 0 + 0.5*400, 375 + 0.5*25);\n",
+       "    <!-- Insert box numbers -->\n",
+       "          context.font = '10pt Times New Roman';\n",
+       "          context.textAlign = 'center';\n",
+       "          context.fillText(2, 0 + 0.5*400, 350 + 0.5*25);\n",
+       "     </script>\n",
+       "  </body>\n",
+       "</html>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stacked_dboard = dashboard.Dashboard()\n",
+    "text_box = {\n",
+    "    'type': 'box',\n",
+    "    'boxType': 'text',\n",
+    "    'text': 'empty space' \n",
+    "}\n",
+    "for _ in range(5):\n",
+    "    stacked_dboard.insert(text_box, 'below', 1)\n",
+    "stacked_dboard.get_preview()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If a dashboard looks like the one above, it may be difficult to grab the handlebars when it is being editted in the [online creator](https://plot.ly/dashboard/create/). To avoid this issue, resize the dashboard:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "stacked_dboard['layout']['size'] = 3000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "COMING SOON: A manual way to change the sizes of the boxes in a dashboard using the Dashboard API."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "deletable": true,
     "editable": true
@@ -795,7 +953,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -808,7 +966,7 @@
        "u'https://plot.ly/~PlotBot/1327/my-first-dashboard-with-python/'"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -851,7 +1009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -864,7 +1022,7 @@
        "['My First Dashboard with Python']"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -875,7 +1033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {
     "collapsed": true,
     "deletable": true,

--- a/_posts/python/fundamentals/dashboard/dashboard-api.ipynb
+++ b/_posts/python/fundamentals/dashboard/dashboard-api.ipynb
@@ -784,7 +784,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "#### Other Settings Options\n",
     "You can adjust other colors of the dashboard too:"
@@ -794,7 +797,9 @@
    "cell_type": "code",
    "execution_count": 33,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -808,7 +813,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "#### Relayout the Dashboard Sizes\n",
     "Right now there is no native way to adjust the sizes of the dashboard boxes. A current issue with stacking boxes in a dashhboard layout is that each added box gets incrementally half as big as the one before it after inserting into the dashboard."
@@ -818,7 +826,9 @@
    "cell_type": "code",
    "execution_count": 46,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -917,7 +927,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "If a dashboard looks like the one above, it may be difficult to grab the handlebars when it is being editted in the [online creator](https://plot.ly/dashboard/create/). To avoid this issue, resize the dashboard:"
    ]
@@ -926,7 +939,9 @@
    "cell_type": "code",
    "execution_count": 49,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -935,7 +950,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "COMING SOON: A manual way to change the sizes of the boxes in a dashboard using the Dashboard API."
    ]
@@ -1202,7 +1220,7 @@
      "output_type": "stream",
      "text": [
       "Collecting git+https://github.com/plotly/publisher.git\n",
-      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-vJqmAY-build\n",
+      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-Abrc2S-build\n",
       "Installing collected packages: publisher\n",
       "  Found existing installation: publisher 0.10\n",
       "    Uninstalling publisher-0.10:\n",


### PR DESCRIPTION
@cldougl ready for review.

I'm adding two sections for more dashboard help:
-section on more settings options for the dashboard (BoxColor, etc)
-how to increase the total size of dashboard (eventually I want this to be programmatic where dashboard size increases based on # of boxes, etc)

Note: the coming soon sec already has an issue for it. I'd rather not expose the non-intuitive structure of a dashboard (i.e. `dashboard['layout']['first']['second'['first']`)