### PR TITLE
fixes back link for /javascript

### DIFF
--- a/_layouts/dashboardly.html
+++ b/_layouts/dashboardly.html
@@ -34,7 +34,9 @@
                                 <path fill="#000000"
                                       d="M20,10V14H11L14.5,17.5L12.08,19.92L4.16,12L12.08,4.08L14.5,6.5L11,10H20Z"/>
                             </svg>
-                        </div>                        <span><a href="/{{page.language}}/">Back to {{page.language | capitalize}}</a></span>
+                        </div>
+                        <span><a href="/{% if page.language == "plotly_js" %}javascript{% else %}{{page.language}}{% endif %}/">Back to {% if page.language == "plotly_js" %}plotly.js{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}MATLAB{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}
+                        </a></span>
                     </button>
                 </nav>
             </div>

--- a/_layouts/getstart-base.html
+++ b/_layouts/getstart-base.html
@@ -37,7 +37,8 @@
 									  d="M20,10V14H11L14.5,17.5L12.08,19.92L4.16,12L12.08,4.08L14.5,6.5L11,10H20Z"/>
 							</svg>
 						</div>
-						<span><a href="/{{page.language}}/">Back to {{page.language | capitalize}}</a></span>
+						<span><a href="/{% if page.language == "plotly_js" %}javascript{% else %}{{page.language}}{% endif %}/">Back to {% if page.language == "plotly_js" %}plotly.js{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}MATLAB{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}
+                        </a></span>
 					</button>
 				</nav>
 			</div>

--- a/_layouts/getstart.html
+++ b/_layouts/getstart.html
@@ -37,7 +37,8 @@
 									  d="M20,10V14H11L14.5,17.5L12.08,19.92L4.16,12L12.08,4.08L14.5,6.5L11,10H20Z"/>
 							</svg>
 						</div>
-						<span><a href="/{{page.language}}/">Back to {{page.language | capitalize}}</a></span>
+						<span><a href="/{% if page.language == "plotly_js" %}javascript{% else %}{{page.language}}{% endif %}/">Back to {% if page.language == "plotly_js" %}plotly.js{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}MATLAB{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}
+                        </a></span>
 					</button>
 				</nav>
 			</div>

--- a/_layouts/user-guide.html
+++ b/_layouts/user-guide.html
@@ -44,7 +44,8 @@
 									  d="M20,10V14H11L14.5,17.5L12.08,19.92L4.16,12L12.08,4.08L14.5,6.5L11,10H20Z"/>
 							</svg>
 						</div>
-						<span><a href="/{{page.language}}/">Back to {{page.language | capitalize}}</a></span>
+						<span><a href="/{% if page.language == "plotly_js" %}javascript{% else %}{{page.language}}{% endif %}/">Back to {% if page.language == "plotly_js" %}plotly.js{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}MATLAB{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}
+                        </a></span>
 					</button>
 				</nav>
 			</div>


### PR DESCRIPTION
On some pages like https://plot.ly/javascript/getting-started/ the "Back to Plotly_js" link points to `/plotly_js` instead of `/javascript` so the user lands on https://plot.y/create instead of where they want to go. 

I copied the fix from `_layouts/base.html` into the files where it was missing.