### PR TITLE
Add more details to python carpet axis documentation

### DIFF
--- a/_posts/python/scientific/carpet/2015-06-30-carpet_plot.html
+++ b/_posts/python/scientific/carpet/2015-06-30-carpet_plot.html
@@ -72,7 +72,7 @@ page_type: u-guide
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h3 id="Set-X-and-Y-Coordinates">Set X and Y Coordinates<a class="anchor-link" href="#Set-X-and-Y-Coordinates">&#182;</a></h3><p>To set the <code>x</code> and <code>y</code> coordinates use <code>x</code> and <code>y</code> attributes. If <code>x</code> coordindate values are ommitted a cheater plot will be created. The plot below has a <code>y</code> array specified but requires <code>a</code> and <code>b</code> values before an axis may be plotted.</p>
+<h3 id="Set-X-and-Y-Coordinates">Set X and Y Coordinates<a class="anchor-link" href="#Set-X-and-Y-Coordinates">&#182;</a></h3><p>To set the <code>x</code> and <code>y</code> coordinates use <code>x</code> and <code>y</code> attributes. If <code>x</code> coordindate values are ommitted a cheater plot will be created. The plot below has a <code>y</code> array specified but requires <code>a</code> and <code>b</code> parameter values before an axis may be plotted.</p>
 
 </div>
 </div>
@@ -241,7 +241,7 @@ page_type: u-guide
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h3 id="Alternate-input-format">Alternate input format<a class="anchor-link" href="#Alternate-input-format">&#182;</a></h3><p>The data arrays <code>x</code>, <code>y</code>, <code>a</code>, and <code>b</code> may either be specified as one-dimensional arrays of data or as arrays of arrays. The plot below represents the same plot as those above.</p>
+<h3 id="Alternate-input-format">Alternate input format<a class="anchor-link" href="#Alternate-input-format">&#182;</a></h3><p>The data arrays <code>x</code>, <code>y</code> may either be specified as one-dimensional arrays of data or as arrays of arrays. If one-dimensional, then <code>x</code>, <code>y</code>, <code>a</code>, and <code>b</code> should all be the same length. If <code>x</code> and <code>y</code> are arrays of arrays, then the length of <code>a</code> should match the inner dimension and the length of <code>b</code> the outer dimension. The plot below represents the same plot as those above.</p>
 
 </div>
 </div>
@@ -304,7 +304,7 @@ page_type: u-guide
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>The layout of cheater plots is not unique and depends upon the <code>cheaterslope</code> and axis <code>cheatertype</code> parameters. If <code>x</code> is not specified, row of the <code>x</code> array is constructed based on the the formula <code>a + cheaterslope * b</code>, where <code>a</code> and <code>b</code> are either the value or the integer index of <code>a</code> and <code>b</code> respectively, depending on the corresponding axis <code>cheatertype</code>. Although the layout of the plot below is different than the plots above, it represents the same data as the plots above.</p>
+<p>The layout of cheater plots is not unique and depends upon the <code>cheaterslope</code> and axis <code>cheatertype</code> parameters. If <code>x</code> is not specified, each row of the <code>x</code> array is constructed based on the the formula <code>a + cheaterslope * b</code>, where <code>a</code> and <code>b</code> are either the value or the integer index of <code>a</code> and <code>b</code> respectively, depending on the corresponding axis <code>cheatertype</code>. Although the layout of the axis below is different than the plots above, it represents the same data as the axes above.</p>
 
 </div>
 </div>

--- a/_posts/python/scientific/carpet/2015-06-30-carpet_plot.html
+++ b/_posts/python/scientific/carpet/2015-06-30-carpet_plot.html
@@ -14,8 +14,7 @@ order: 26
 page_type: u-guide
 ---
 {% raw %}
-<div class="cell border-box-sizing text_cell rendered">
-<div class="prompt input_prompt">
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
@@ -26,8 +25,7 @@ page_type: u-guide
 </div>
 </div>
 </div>
-<div class="cell border-box-sizing text_cell rendered">
-<div class="prompt input_prompt">
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
@@ -54,12 +52,14 @@ page_type: u-guide
 
 
 <div class="output_area">
+
 <div class="prompt output_prompt">Out[1]:</div>
 
 
 
+
 <div class="output_text output_subarea output_execute_result">
-<pre>&#39;2.0.8&#39;</pre>
+<pre>&#39;2.0.15&#39;</pre>
 </div>
 
 </div>
@@ -68,12 +68,11 @@ page_type: u-guide
 </div>
 
 </div>
-<div class="cell border-box-sizing text_cell rendered">
-<div class="prompt input_prompt">
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h3 id="Set-X-and-Y-Coordinates">Set X and Y Coordinates<a class="anchor-link" href="#Set-X-and-Y-Coordinates">&#182;</a></h3><p>To set the <code>x</code> and <code>y</code> coordinates use <code>x</code> and <code>y</code> attributes. If <code>x</code> coorindate values are ommitted a cheater plot will be created.</p>
+<h3 id="Set-X-and-Y-Coordinates">Set X and Y Coordinates<a class="anchor-link" href="#Set-X-and-Y-Coordinates">&#182;</a></h3><p>To set the <code>x</code> and <code>y</code> coordinates use <code>x</code> and <code>y</code> attributes. If <code>x</code> coordindate values are ommitted a cheater plot will be created. The plot below has a <code>y</code> array specified but requires <code>a</code> and <code>b</code> values before an axis may be plotted.</p>
 
 </div>
 </div>
@@ -105,11 +104,13 @@ page_type: u-guide
 
 
 <div class="output_area">
+
 <div class="prompt output_prompt">Out[2]:</div>
 
 
+
 <div class="output_html rendered_html output_subarea output_execute_result">
-<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~PythonPlotBot/2006.embed" height="525px" width="100%"></iframe>
+<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~rreusser/103.embed" height="525px" width="100%"></iframe>
 </div>
 
 </div>
@@ -118,8 +119,7 @@ page_type: u-guide
 </div>
 
 </div>
-<div class="cell border-box-sizing text_cell rendered">
-<div class="prompt input_prompt">
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
@@ -157,11 +157,13 @@ page_type: u-guide
 
 
 <div class="output_area">
+
 <div class="prompt output_prompt">Out[3]:</div>
 
 
+
 <div class="output_html rendered_html output_subarea output_execute_result">
-<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~PythonPlotBot/2008.embed" height="525px" width="100%"></iframe>
+<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~rreusser/105.embed" height="525px" width="100%"></iframe>
 </div>
 
 </div>
@@ -170,8 +172,7 @@ page_type: u-guide
 </div>
 
 </div>
-<div class="cell border-box-sizing text_cell rendered">
-<div class="prompt input_prompt">
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
@@ -221,11 +222,13 @@ page_type: u-guide
 
 
 <div class="output_area">
+
 <div class="prompt output_prompt">Out[4]:</div>
 
 
+
 <div class="output_html rendered_html output_subarea output_execute_result">
-<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~PythonPlotBot/2010.embed" height="525px" width="100%"></iframe>
+<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~rreusser/107.embed" height="525px" width="100%"></iframe>
 </div>
 
 </div>
@@ -234,8 +237,128 @@ page_type: u-guide
 </div>
 
 </div>
-<div class="cell border-box-sizing text_cell rendered">
-<div class="prompt input_prompt">
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h3 id="Alternate-input-format">Alternate input format<a class="anchor-link" href="#Alternate-input-format">&#182;</a></h3><p>The data arrays <code>x</code>, <code>y</code>, <code>a</code>, and <code>b</code> may either be specified as one-dimensional arrays of data or as arrays of arrays. The plot below represents the same plot as those above.</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[5]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">plotly.graph_objs</span> <span class="kn">as</span> <span class="nn">go</span>
+<span class="kn">import</span> <span class="nn">plotly.plotly</span> <span class="kn">as</span> <span class="nn">py</span>
+
+<span class="n">trace1</span> <span class="o">=</span> <span class="n">go</span><span class="o">.</span><span class="n">Carpet</span><span class="p">(</span>
+    <span class="n">a</span> <span class="o">=</span> <span class="p">[</span><span class="mi">4</span><span class="p">,</span> <span class="mf">4.5</span><span class="p">,</span> <span class="mi">5</span><span class="p">,</span> <span class="mi">6</span><span class="p">],</span>
+    <span class="n">b</span> <span class="o">=</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">3</span><span class="p">],</span>
+    <span class="n">y</span> <span class="o">=</span> <span class="p">[[</span><span class="mi">2</span><span class="p">,</span> <span class="mi">3</span><span class="p">,</span> <span class="mf">5.5</span><span class="p">,</span> <span class="mi">8</span><span class="p">],</span>
+         <span class="p">[</span><span class="mf">3.5</span><span class="p">,</span> <span class="mf">4.5</span><span class="p">,</span> <span class="mf">6.5</span><span class="p">,</span> <span class="mf">8.5</span><span class="p">],</span>
+         <span class="p">[</span><span class="mi">4</span><span class="p">,</span> <span class="mi">5</span><span class="p">,</span> <span class="mf">7.5</span><span class="p">,</span> <span class="mi">10</span><span class="p">]]</span>
+<span class="p">)</span>
+
+<span class="n">data</span> <span class="o">=</span> <span class="p">[</span><span class="n">trace1</span><span class="p">]</span>
+
+<span class="n">fig</span> <span class="o">=</span> <span class="n">go</span><span class="o">.</span><span class="n">Figure</span><span class="p">(</span><span class="n">data</span> <span class="o">=</span> <span class="n">data</span><span class="p">)</span>
+<span class="n">py</span><span class="o">.</span><span class="n">iplot</span><span class="p">(</span><span class="n">fig</span><span class="p">,</span> <span class="n">filename</span> <span class="o">=</span> <span class="s2">&quot;carpet/input-format&quot;</span><span class="p">)</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+<div class="prompt output_prompt">Out[5]:</div>
+
+
+
+<div class="output_html rendered_html output_subarea output_execute_result">
+<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~rreusser/111.embed" height="525px" width="100%"></iframe>
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h3 id="Cheater-plot-layout">Cheater plot layout<a class="anchor-link" href="#Cheater-plot-layout">&#182;</a></h3>
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>The layout of cheater plots is not unique and depends upon the <code>cheaterslope</code> and axis <code>cheatertype</code> parameters. If <code>x</code> is not specified, row of the <code>x</code> array is constructed based on the the formula <code>a + cheaterslope * b</code>, where <code>a</code> and <code>b</code> are either the value or the integer index of <code>a</code> and <code>b</code> respectively, depending on the corresponding axis <code>cheatertype</code>. Although the layout of the plot below is different than the plots above, it represents the same data as the plots above.</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[6]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">plotly.graph_objs</span> <span class="kn">as</span> <span class="nn">go</span>
+<span class="kn">import</span> <span class="nn">plotly.plotly</span> <span class="kn">as</span> <span class="nn">py</span>
+
+<span class="n">trace1</span> <span class="o">=</span> <span class="n">go</span><span class="o">.</span><span class="n">Carpet</span><span class="p">(</span>
+    <span class="n">a</span> <span class="o">=</span> <span class="p">[</span><span class="mi">4</span><span class="p">,</span> <span class="mf">4.5</span><span class="p">,</span> <span class="mi">5</span><span class="p">,</span> <span class="mi">6</span><span class="p">],</span>
+    <span class="n">b</span> <span class="o">=</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">3</span><span class="p">],</span>
+    <span class="n">y</span> <span class="o">=</span> <span class="p">[[</span><span class="mi">2</span><span class="p">,</span> <span class="mi">3</span><span class="p">,</span> <span class="mf">5.5</span><span class="p">,</span> <span class="mi">8</span><span class="p">],</span>
+         <span class="p">[</span><span class="mf">3.5</span><span class="p">,</span> <span class="mf">4.5</span><span class="p">,</span> <span class="mf">6.5</span><span class="p">,</span> <span class="mf">8.5</span><span class="p">],</span>
+         <span class="p">[</span><span class="mi">4</span><span class="p">,</span> <span class="mi">5</span><span class="p">,</span> <span class="mf">7.5</span><span class="p">,</span> <span class="mi">10</span><span class="p">]],</span>
+    <span class="n">cheaterslope</span> <span class="o">=</span> <span class="o">-</span><span class="mi">5</span><span class="p">,</span>
+    <span class="n">aaxis</span> <span class="o">=</span> <span class="nb">dict</span><span class="p">(</span><span class="n">cheatertype</span> <span class="o">=</span> <span class="s1">&#39;index&#39;</span><span class="p">),</span>
+    <span class="n">baxis</span> <span class="o">=</span> <span class="nb">dict</span><span class="p">(</span><span class="n">cheatertype</span> <span class="o">=</span> <span class="s1">&#39;value&#39;</span><span class="p">)</span>
+<span class="p">)</span>
+
+<span class="n">data</span> <span class="o">=</span> <span class="p">[</span><span class="n">trace1</span><span class="p">]</span>
+
+<span class="n">fig</span> <span class="o">=</span> <span class="n">go</span><span class="o">.</span><span class="n">Figure</span><span class="p">(</span><span class="n">data</span> <span class="o">=</span> <span class="n">data</span><span class="p">)</span>
+<span class="n">py</span><span class="o">.</span><span class="n">iplot</span><span class="p">(</span><span class="n">fig</span><span class="p">,</span> <span class="n">filename</span> <span class="o">=</span> <span class="s2">&quot;carpet/cheater-layout&quot;</span><span class="p">)</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+<div class="prompt output_prompt">Out[6]:</div>
+
+
+
+<div class="output_html rendered_html output_subarea output_execute_result">
+<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~rreusser/113.embed" height="525px" width="100%"></iframe>
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
@@ -245,7 +368,7 @@ page_type: u-guide
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[5]:</div>
+<div class="prompt input_prompt">In&nbsp;[7]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">plotly.graph_objs</span> <span class="kn">as</span> <span class="nn">go</span>
@@ -279,14 +402,14 @@ page_type: u-guide
 <span class="n">data</span> <span class="o">=</span> <span class="p">[</span><span class="n">trace1</span><span class="p">]</span>
 
 <span class="n">layout</span> <span class="o">=</span> <span class="n">go</span><span class="o">.</span><span class="n">Layout</span><span class="p">(</span>
-    <span class="n">plot_bgcolor</span> <span class="o">=</span> <span class="s1">&#39;black&#39;</span><span class="p">,</span>
+    <span class="n">plot_bgcolor</span> <span class="o">=</span> <span class="s1">&#39;black&#39;</span><span class="p">,</span> 
     <span class="n">paper_bgcolor</span> <span class="o">=</span> <span class="s1">&#39;black&#39;</span><span class="p">,</span>
     <span class="n">xaxis</span> <span class="o">=</span> <span class="nb">dict</span><span class="p">(</span>
-        <span class="n">showgrid</span> <span class="o">=</span> <span class="bp">False</span><span class="p">,</span>
+        <span class="n">showgrid</span> <span class="o">=</span> <span class="bp">False</span><span class="p">,</span> 
         <span class="n">showticklabels</span> <span class="o">=</span> <span class="bp">False</span>
     <span class="p">),</span>
     <span class="n">yaxis</span> <span class="o">=</span> <span class="nb">dict</span><span class="p">(</span>
-        <span class="n">showgrid</span> <span class="o">=</span> <span class="bp">False</span><span class="p">,</span>
+        <span class="n">showgrid</span> <span class="o">=</span> <span class="bp">False</span><span class="p">,</span> 
         <span class="n">showticklabels</span> <span class="o">=</span> <span class="bp">False</span>
     <span class="p">)</span>
 <span class="p">)</span>
@@ -304,11 +427,13 @@ page_type: u-guide
 
 
 <div class="output_area">
-<div class="prompt output_prompt">Out[5]:</div>
+
+<div class="prompt output_prompt">Out[7]:</div>
+
 
 
 <div class="output_html rendered_html output_subarea output_execute_result">
-<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~PythonPlotBot/2012.embed" height="525px" width="100%"></iframe>
+<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~rreusser/109.embed" height="525px" width="100%"></iframe>
 </div>
 
 </div>
@@ -317,18 +442,16 @@ page_type: u-guide
 </div>
 
 </div>
-<div class="cell border-box-sizing text_cell rendered">
-<div class="prompt input_prompt">
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h3 id="Add-Points-and-Contours">Add Points and Contours<a class="anchor-link" href="#Add-Points-and-Contours">&#182;</a></h3><p>To add points and lines see <a href="https://plot.ly/python/carpet-scatter">Carpet Scatter Plots</a> or to add contours see <a href="https://plot.ly/python/carpet-contour">Carpet Contour Plots</a></p>
+<h3 id="Add-Points-and-Contours">Add Points and Contours<a class="anchor-link" href="#Add-Points-and-Contours">&#182;</a></h3><p>To add points and lines see <a href="https://plot.ly/r/carpet-scatter">Carpet Scatter Plots</a> or to add contours see <a href="https://plot.ly/carpet-contour">Carpet Contour Plots</a></p>
 
 </div>
 </div>
 </div>
-<div class="cell border-box-sizing text_cell rendered">
-<div class="prompt input_prompt">
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
@@ -336,6 +459,15 @@ page_type: u-guide
 </div>
 </div>
 </div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>See <a href="https://plot.ly/python/reference/#carpet">https://plot.ly/python/reference/#carpet</a> for more information and chart attribute options!</p>
 
+</div>
+</div>
+</div>
+ 
 
 {% endraw %}

--- a/_posts/python/scientific/carpet/carpet_plot.ipynb
+++ b/_posts/python/scientific/carpet/carpet_plot.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false,
     "inputHidden": false,
     "outputHidden": false
    },
@@ -26,7 +25,6 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false,
     "inputHidden": false,
     "outputHidden": false
    },
@@ -34,7 +32,7 @@
     {
      "data": {
       "text/plain": [
-       "'2.0.8'"
+       "'2.0.15'"
       ]
      },
      "execution_count": 1,
@@ -54,20 +52,18 @@
     "### Set X and Y Coordinates\n",
     "\n",
     "\n",
-    "To set the `x` and `y` coordinates use `x` and `y` attributes. If `x` coorindate values are ommitted a cheater plot will be created."
+    "To set the `x` and `y` coordinates use `x` and `y` attributes. If `x` coordindate values are ommitted a cheater plot will be created. The plot below has a `y` array specified but requires `a` and `b` values before an axis may be plotted."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~PythonPlotBot/2006.embed\" height=\"525px\" width=\"100%\"></iframe>"
+       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~rreusser/103.embed\" height=\"525px\" width=\"100%\"></iframe>"
       ],
       "text/plain": [
        "<plotly.tools.PlotlyDisplay object>"
@@ -105,7 +101,6 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": false,
     "inputHidden": false,
     "outputHidden": false
    },
@@ -113,7 +108,7 @@
     {
      "data": {
       "text/html": [
-       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~PythonPlotBot/2008.embed\" height=\"525px\" width=\"100%\"></iframe>"
+       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~rreusser/105.embed\" height=\"525px\" width=\"100%\"></iframe>"
       ],
       "text/plain": [
        "<plotly.tools.PlotlyDisplay object>"
@@ -153,15 +148,15 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "collapsed": false,
     "inputHidden": false,
-    "outputHidden": false
+    "outputHidden": false,
+    "scrolled": false
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~PythonPlotBot/2010.embed\" height=\"525px\" width=\"100%\"></iframe>"
+       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~rreusser/107.embed\" height=\"525px\" width=\"100%\"></iframe>"
       ],
       "text/plain": [
        "<plotly.tools.PlotlyDisplay object>"
@@ -204,14 +199,113 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Style A and B axis"
+    "### Alternate input format\n",
+    "\n",
+    "The data arrays `x`, `y`, `a`, and `b` may either be specified as one-dimensional arrays of data or as arrays of arrays. The plot below represents the same plot as those above."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~rreusser/111.embed\" height=\"525px\" width=\"100%\"></iframe>"
+      ],
+      "text/plain": [
+       "<plotly.tools.PlotlyDisplay object>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import plotly.graph_objs as go\n",
+    "import plotly.plotly as py\n",
+    "\n",
+    "trace1 = go.Carpet(\n",
+    "    a = [4, 4.5, 5, 6],\n",
+    "    b = [1, 2, 3],\n",
+    "    y = [[2, 3, 5.5, 8],\n",
+    "         [3.5, 4.5, 6.5, 8.5],\n",
+    "         [4, 5, 7.5, 10]]\n",
+    ")\n",
+    "\n",
+    "data = [trace1]\n",
+    "\n",
+    "fig = go.Figure(data = data)\n",
+    "py.iplot(fig, filename = \"carpet/input-format\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cheater plot layout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The layout of cheater plots is not unique and depends upon the `cheaterslope` and axis `cheatertype` parameters. If `x` is not specified, row of the `x` array is constructed based on the the formula `a + cheaterslope * b`, where `a` and `b` are either the value or the integer index of `a` and `b` respectively, depending on the corresponding axis `cheatertype`. Although the layout of the plot below is different than the plots above, it represents the same data as the plots above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~rreusser/113.embed\" height=\"525px\" width=\"100%\"></iframe>"
+      ],
+      "text/plain": [
+       "<plotly.tools.PlotlyDisplay object>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import plotly.graph_objs as go\n",
+    "import plotly.plotly as py\n",
+    "\n",
+    "trace1 = go.Carpet(\n",
+    "    a = [4, 4.5, 5, 6],\n",
+    "    b = [1, 2, 3],\n",
+    "    y = [[2, 3, 5.5, 8],\n",
+    "         [3.5, 4.5, 6.5, 8.5],\n",
+    "         [4, 5, 7.5, 10]],\n",
+    "    cheaterslope = -5,\n",
+    "    aaxis = dict(cheatertype = 'index'),\n",
+    "    baxis = dict(cheatertype = 'value')\n",
+    ")\n",
+    "\n",
+    "data = [trace1]\n",
+    "\n",
+    "fig = go.Figure(data = data)\n",
+    "py.iplot(fig, filename = \"carpet/cheater-layout\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Style A and B axis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {
-    "collapsed": false,
     "inputHidden": false,
     "outputHidden": false
    },
@@ -219,13 +313,13 @@
     {
      "data": {
       "text/html": [
-       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~PythonPlotBot/2012.embed\" height=\"525px\" width=\"100%\"></iframe>"
+       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~rreusser/109.embed\" height=\"525px\" width=\"100%\"></iframe>"
       ],
       "text/plain": [
        "<plotly.tools.PlotlyDisplay object>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -303,10 +397,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -337,28 +429,13 @@
      "output_type": "stream",
      "text": [
       "Collecting git+https://github.com/plotly/publisher.git\n",
-      "  Cloning https://github.com/plotly/publisher.git to c:\\users\\branden\\appdata\\local\\temp\\pip-vrcl560k-build\n",
+      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/5s/mm8_jrls0zd34zkb1z71xb940000gp/T/pip-KsfVTq-build\n",
       "Installing collected packages: publisher\n",
       "  Found existing installation: publisher 0.10\n",
       "    Uninstalling publisher-0.10:\n",
       "      Successfully uninstalled publisher-0.10\n",
-      "  Running setup.py install for publisher: started\n",
-      "    Running setup.py install for publisher: finished with status 'done'\n",
-      "Successfully installed publisher-0.10\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\Branden\\Anaconda3\\envs\\ipykernel_py2\\lib\\site-packages\\IPython\\nbconvert.py:13: ShimWarning:\n",
-      "\n",
-      "The `IPython.nbconvert` package has been deprecated. You should import from nbconvert instead.\n",
-      "\n",
-      "C:\\Users\\Branden\\Anaconda3\\envs\\ipykernel_py2\\lib\\site-packages\\publisher\\publisher.py:53: UserWarning:\n",
-      "\n",
-      "Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
-      "\n"
+      "  Running setup.py install for publisher ... \u001b[?25ldone\n",
+      "\u001b[?25hSuccessfully installed publisher-0.10\n"
      ]
     }
    ],
@@ -411,7 +488,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/_posts/python/scientific/carpet/carpet_plot.ipynb
+++ b/_posts/python/scientific/carpet/carpet_plot.ipynb
@@ -52,7 +52,7 @@
     "### Set X and Y Coordinates\n",
     "\n",
     "\n",
-    "To set the `x` and `y` coordinates use `x` and `y` attributes. If `x` coordindate values are ommitted a cheater plot will be created. The plot below has a `y` array specified but requires `a` and `b` values before an axis may be plotted."
+    "To set the `x` and `y` coordinates use `x` and `y` attributes. If `x` coordindate values are ommitted a cheater plot will be created. The plot below has a `y` array specified but requires `a` and `b` parameter values before an axis may be plotted."
    ]
   },
   {
@@ -201,7 +201,7 @@
    "source": [
     "### Alternate input format\n",
     "\n",
-    "The data arrays `x`, `y`, `a`, and `b` may either be specified as one-dimensional arrays of data or as arrays of arrays. The plot below represents the same plot as those above."
+    "The data arrays `x`, `y` may either be specified as one-dimensional arrays of data or as arrays of arrays. If one-dimensional, then `x`, `y`, `a`, and `b` should all be the same length. If `x` and `y` are arrays of arrays, then the length of `a` should match the inner dimension and the length of `b` the outer dimension. The plot below represents the same plot as those above."
    ]
   },
   {
@@ -252,7 +252,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The layout of cheater plots is not unique and depends upon the `cheaterslope` and axis `cheatertype` parameters. If `x` is not specified, row of the `x` array is constructed based on the the formula `a + cheaterslope * b`, where `a` and `b` are either the value or the integer index of `a` and `b` respectively, depending on the corresponding axis `cheatertype`. Although the layout of the plot below is different than the plots above, it represents the same data as the plots above."
+    "The layout of cheater plots is not unique and depends upon the `cheaterslope` and axis `cheatertype` parameters. If `x` is not specified, each row of the `x` array is constructed based on the the formula `a + cheaterslope * b`, where `a` and `b` are either the value or the integer index of `a` and `b` respectively, depending on the corresponding axis `cheatertype`. Although the layout of the axis below is different than the plots above, it represents the same data as the axes above."
    ]
   },
   {
@@ -397,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -429,13 +429,27 @@
      "output_type": "stream",
      "text": [
       "Collecting git+https://github.com/plotly/publisher.git\n",
-      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/5s/mm8_jrls0zd34zkb1z71xb940000gp/T/pip-KsfVTq-build\n",
+      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/5s/mm8_jrls0zd34zkb1z71xb940000gp/T/pip-1vLBzZ-build\n",
       "Installing collected packages: publisher\n",
       "  Found existing installation: publisher 0.10\n",
       "    Uninstalling publisher-0.10:\n",
       "      Successfully uninstalled publisher-0.10\n",
       "  Running setup.py install for publisher ... \u001b[?25ldone\n",
       "\u001b[?25hSuccessfully installed publisher-0.10\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/rreusser/anaconda2/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning:\n",
+      "\n",
+      "The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
+      "\n",
+      "/Users/rreusser/anaconda2/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning:\n",
+      "\n",
+      "Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
+      "\n"
      ]
     }
    ],


### PR DESCRIPTION
This PR adds some additional information to the python carpet plot docs. In particular:

## Note on why the first plot is blank:

<img width="822" alt="screen shot 2017-09-27 at 17 08 59" src="https://user-images.githubusercontent.com/572717/30943561-9dc3873e-a3a6-11e7-82b7-ca94415a7048.png">


## Note on array-of-arrays input format:

<img width="849" alt="screen shot 2017-09-27 at 17 09 07" src="https://user-images.githubusercontent.com/572717/30943564-a17142f4-a3a6-11e7-914d-f71e2812db7a.png">

## Note on control of non-unique cheater plot layout:

<img width="851" alt="screen shot 2017-09-27 at 17 09 13" src="https://user-images.githubusercontent.com/572717/30943566-a4e63fe8-a3a6-11e7-99a1-971e2bb15135.png">