### PR TITLE
redirect presentations url...

### DIFF
--- a/_posts/python/fundamentals/presentations/2015-06-30-presentations-api.html
+++ b/_posts/python/fundamentals/presentations/2015-06-30-presentations-api.html
@@ -86,6 +86,49 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
+<h4 id="Display-in-Jupyter">Display in Jupyter<a class="anchor-link" href="#Display-in-Jupyter">&#194;&#182;</a></h4><p>The function below generates HTML code to display the presentation in an iframe directly in Jupyter.</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[3]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython2"><pre><span></span><span class="k">def</span> <span class="nf">url_to_iframe</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">text</span><span class="o">=</span><span class="bp">True</span><span class="p">):</span>
+    <span class="n">html</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>
+    <span class="c1"># style</span>
+    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;head&gt;</span>
+<span class="s1">    &lt;style&gt;</span>
+<span class="s1">    div.textbox {</span>
+<span class="s1">        margin: 30px;</span>
+<span class="s1">        font-weight: bold;   </span>
+<span class="s1">    }</span>
+<span class="s1">    &lt;/style&gt;</span>
+<span class="s1">    &lt;/head&gt;&#39;</span>
+<span class="s1">    &#39;&#39;&#39;</span>
+    <span class="c1"># iframe</span>
+    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&lt;iframe src=&#39;</span> <span class="o">+</span> <span class="n">url</span> <span class="o">+</span> <span class="s1">&#39;.embed#{} width=750 height=400 frameBorder=&quot;0&quot;&gt;&lt;/iframe&gt;&#39;</span>
+    <span class="k">if</span> <span class="n">text</span><span class="p">:</span>
+        <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;body&gt;</span>
+<span class="s1">        &lt;div class=&quot;textbox&quot;&gt;</span>
+<span class="s1">            &lt;p&gt;Click on the presentation above and use left/right arrow keys to flip through the slides.&lt;/p&gt;</span>
+<span class="s1">        &lt;/div&gt;</span>
+<span class="s1">        &lt;/body&gt;</span>
+<span class="s1">        &#39;&#39;&#39;</span>
+    <span class="k">return</span> <span class="n">html</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
 <h4 id="Simple-Example">Simple Example<a class="anchor-link" href="#Simple-Example">&#194;&#182;</a></h4>
 </div>
 </div>
@@ -133,29 +176,6 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">IPython</span>
-
-<span class="k">def</span> <span class="nf">url_to_iframe</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">text</span><span class="o">=</span><span class="bp">True</span><span class="p">):</span>
-    <span class="n">html</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>
-    <span class="c1"># style</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;head&gt;</span>
-<span class="s1">    &lt;style&gt;</span>
-<span class="s1">    div.textbox {</span>
-<span class="s1">        margin: 30px;</span>
-<span class="s1">        font-weight: bold;   </span>
-<span class="s1">    }</span>
-<span class="s1">    &lt;/style&gt;</span>
-<span class="s1">    &lt;/head&gt;&#39;</span>
-<span class="s1">    &#39;&#39;&#39;</span>
-    <span class="c1"># iframe</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&lt;iframe src=&#39;</span> <span class="o">+</span> <span class="n">url</span> <span class="o">+</span> <span class="s1">&#39;.embed#{} width=750 height=400 frameBorder=&quot;0&quot;&gt;&lt;/iframe&gt;&#39;</span>
-    <span class="k">if</span> <span class="n">text</span><span class="p">:</span>
-        <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;body&gt;</span>
-<span class="s1">        &lt;div class=&quot;textbox&quot;&gt;</span>
-<span class="s1">            &lt;p&gt;Click on the presentation above and use left/right arrow keys to flip through the slides.&lt;/p&gt;</span>
-<span class="s1">        &lt;/div&gt;</span>
-<span class="s1">        &lt;/body&gt;</span>
-<span class="s1">        &#39;&#39;&#39;</span>
-    <span class="k">return</span> <span class="n">html</span>
 
 <span class="n">iframe_0</span> <span class="o">=</span> <span class="n">url_to_iframe</span><span class="p">(</span><span class="n">pres_url_0</span><span class="p">,</span> <span class="bp">True</span><span class="p">)</span>
 <span class="n">IPython</span><span class="o">.</span><span class="n">display</span><span class="o">.</span><span class="n">HTML</span><span class="p">(</span><span class="n">iframe_0</span><span class="p">)</span>
@@ -264,29 +284,6 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">IPython</span>
 
-<span class="k">def</span> <span class="nf">url_to_iframe</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">text</span><span class="o">=</span><span class="bp">True</span><span class="p">):</span>
-    <span class="n">html</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>
-    <span class="c1"># style</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;head&gt;</span>
-<span class="s1">    &lt;style&gt;</span>
-<span class="s1">    div.textbox {</span>
-<span class="s1">        margin: 30px;</span>
-<span class="s1">        font-weight: bold;   </span>
-<span class="s1">    }</span>
-<span class="s1">    &lt;/style&gt;</span>
-<span class="s1">    &lt;/head&gt;&#39;</span>
-<span class="s1">    &#39;&#39;&#39;</span>
-    <span class="c1"># iframe</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&lt;iframe src=&#39;</span> <span class="o">+</span> <span class="n">url</span> <span class="o">+</span> <span class="s1">&#39;.embed#{} width=750 height=400 frameBorder=&quot;0&quot;&gt;&lt;/iframe&gt;&#39;</span>
-    <span class="k">if</span> <span class="n">text</span><span class="p">:</span>
-        <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;body&gt;</span>
-<span class="s1">        &lt;div class=&quot;textbox&quot;&gt;</span>
-<span class="s1">            &lt;p&gt;Click on the presentation above and use left/right arrow keys to flip through the slides.&lt;/p&gt;</span>
-<span class="s1">        &lt;/div&gt;</span>
-<span class="s1">        &lt;/body&gt;</span>
-<span class="s1">        &#39;&#39;&#39;</span>
-    <span class="k">return</span> <span class="n">html</span>
-
 <span class="n">iframe_1</span> <span class="o">=</span> <span class="n">url_to_iframe</span><span class="p">(</span><span class="n">pres_url_1</span><span class="p">,</span> <span class="bp">True</span><span class="p">)</span>
 <span class="n">IPython</span><span class="o">.</span><span class="n">display</span><span class="o">.</span><span class="n">HTML</span><span class="p">(</span><span class="n">iframe_1</span><span class="p">)</span>
 </pre></div>
@@ -389,29 +386,6 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">IPython</span>
 
-<span class="k">def</span> <span class="nf">url_to_iframe</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">text</span><span class="o">=</span><span class="bp">True</span><span class="p">):</span>
-    <span class="n">html</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>
-    <span class="c1"># style</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;head&gt;</span>
-<span class="s1">    &lt;style&gt;</span>
-<span class="s1">    div.textbox {</span>
-<span class="s1">        margin: 30px;</span>
-<span class="s1">        font-weight: bold;   </span>
-<span class="s1">    }</span>
-<span class="s1">    &lt;/style&gt;</span>
-<span class="s1">    &lt;/head&gt;&#39;</span>
-<span class="s1">    &#39;&#39;&#39;</span>
-    <span class="c1"># iframe</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&lt;iframe src=&#39;</span> <span class="o">+</span> <span class="n">url</span> <span class="o">+</span> <span class="s1">&#39;.embed#{} width=750 height=400 frameBorder=&quot;0&quot;&gt;&lt;/iframe&gt;&#39;</span>
-    <span class="k">if</span> <span class="n">text</span><span class="p">:</span>
-        <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;body&gt;</span>
-<span class="s1">        &lt;div class=&quot;textbox&quot;&gt;</span>
-<span class="s1">            &lt;p&gt;Click on the presentation above and use left/right arrow keys to flip through the slides.&lt;/p&gt;</span>
-<span class="s1">        &lt;/div&gt;</span>
-<span class="s1">        &lt;/body&gt;</span>
-<span class="s1">        &#39;&#39;&#39;</span>
-    <span class="k">return</span> <span class="n">html</span>
-
 <span class="n">iframe_2</span> <span class="o">=</span> <span class="n">url_to_iframe</span><span class="p">(</span><span class="n">pres_url_2</span><span class="p">,</span> <span class="bp">True</span><span class="p">)</span>
 <span class="n">IPython</span><span class="o">.</span><span class="n">display</span><span class="o">.</span><span class="n">HTML</span><span class="p">(</span><span class="n">iframe_2</span><span class="p">)</span>
 </pre></div>
@@ -481,7 +455,6 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 <span class="s2">Image(https://raw.githubusercontent.com/jackparmer/gradient-backgrounds/master/moods1.png)</span>
 <span class="s2">&quot;&quot;&quot;</span>
 
-
 <span class="n">my_pres</span> <span class="o">=</span> <span class="n">pres</span><span class="o">.</span><span class="n">Presentation</span><span class="p">(</span><span class="n">markdown_string</span><span class="p">,</span> <span class="n">imgStretch</span><span class="o">=</span><span class="bp">False</span><span class="p">)</span>
 <span class="n">pres_url_3</span> <span class="o">=</span> <span class="n">py</span><span class="o">.</span><span class="n">presentation_ops</span><span class="o">.</span><span class="n">upload</span><span class="p">(</span><span class="n">my_pres</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
 </pre></div>
@@ -506,29 +479,6 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">IPython</span>
-
-<span class="k">def</span> <span class="nf">url_to_iframe</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">text</span><span class="o">=</span><span class="bp">True</span><span class="p">):</span>
-    <span class="n">html</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>
-    <span class="c1"># style</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;head&gt;</span>
-<span class="s1">    &lt;style&gt;</span>
-<span class="s1">    div.textbox {</span>
-<span class="s1">        margin: 30px;</span>
-<span class="s1">        font-weight: bold;   </span>
-<span class="s1">    }</span>
-<span class="s1">    &lt;/style&gt;</span>
-<span class="s1">    &lt;/head&gt;&#39;</span>
-<span class="s1">    &#39;&#39;&#39;</span>
-    <span class="c1"># iframe</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&lt;iframe src=&#39;</span> <span class="o">+</span> <span class="n">url</span> <span class="o">+</span> <span class="s1">&#39;.embed#{} width=750 height=400 frameBorder=&quot;0&quot;&gt;&lt;/iframe&gt;&#39;</span>
-    <span class="k">if</span> <span class="n">text</span><span class="p">:</span>
-        <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;body&gt;</span>
-<span class="s1">        &lt;div class=&quot;textbox&quot;&gt;</span>
-<span class="s1">            &lt;p&gt;Click on the presentation above and use left/right arrow keys to flip through the slides.&lt;/p&gt;</span>
-<span class="s1">        &lt;/div&gt;</span>
-<span class="s1">        &lt;/body&gt;</span>
-<span class="s1">        &#39;&#39;&#39;</span>
-    <span class="k">return</span> <span class="n">html</span>
 
 <span class="n">iframe_3</span> <span class="o">=</span> <span class="n">url_to_iframe</span><span class="p">(</span><span class="n">pres_url_3</span><span class="p">,</span> <span class="bp">False</span><span class="p">)</span>
 <span class="n">IPython</span><span class="o">.</span><span class="n">display</span><span class="o">.</span><span class="n">HTML</span><span class="p">(</span><span class="n">iframe_3</span><span class="p">)</span>
@@ -706,29 +656,6 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">IPython</span>
 
-<span class="k">def</span> <span class="nf">url_to_iframe</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">text</span><span class="o">=</span><span class="bp">True</span><span class="p">):</span>
-    <span class="n">html</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>
-    <span class="c1"># style</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;head&gt;</span>
-<span class="s1">    &lt;style&gt;</span>
-<span class="s1">    div.textbox {</span>
-<span class="s1">        margin: 30px;</span>
-<span class="s1">        font-weight: bold;   </span>
-<span class="s1">    }</span>
-<span class="s1">    &lt;/style&gt;</span>
-<span class="s1">    &lt;/head&gt;&#39;</span>
-<span class="s1">    &#39;&#39;&#39;</span>
-    <span class="c1"># iframe</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&lt;iframe src=&#39;</span> <span class="o">+</span> <span class="n">url</span> <span class="o">+</span> <span class="s1">&#39;.embed#{} width=750 height=400 frameBorder=&quot;0&quot;&gt;&lt;/iframe&gt;&#39;</span>
-    <span class="k">if</span> <span class="n">text</span><span class="p">:</span>
-        <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;body&gt;</span>
-<span class="s1">        &lt;div class=&quot;textbox&quot;&gt;</span>
-<span class="s1">            &lt;p&gt;Click on the presentation above and use left/right arrow keys to flip through the slides.&lt;/p&gt;</span>
-<span class="s1">        &lt;/div&gt;</span>
-<span class="s1">        &lt;/body&gt;</span>
-<span class="s1">        &#39;&#39;&#39;</span>
-    <span class="k">return</span> <span class="n">html</span>
-
 <span class="n">iframe_4</span> <span class="o">=</span> <span class="n">url_to_iframe</span><span class="p">(</span><span class="n">pres_url_4</span><span class="p">,</span> <span class="bp">True</span><span class="p">)</span>
 <span class="n">IPython</span><span class="o">.</span><span class="n">display</span><span class="o">.</span><span class="n">HTML</span><span class="p">(</span><span class="n">iframe_4</span><span class="p">)</span>
 </pre></div>
@@ -895,29 +822,6 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">IPython</span>
 
-<span class="k">def</span> <span class="nf">url_to_iframe</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">text</span><span class="o">=</span><span class="bp">True</span><span class="p">):</span>
-    <span class="n">html</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>
-    <span class="c1"># style</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;head&gt;</span>
-<span class="s1">    &lt;style&gt;</span>
-<span class="s1">    div.textbox {</span>
-<span class="s1">        margin: 30px;</span>
-<span class="s1">        font-weight: bold;   </span>
-<span class="s1">    }</span>
-<span class="s1">    &lt;/style&gt;</span>
-<span class="s1">    &lt;/head&gt;&#39;</span>
-<span class="s1">    &#39;&#39;&#39;</span>
-    <span class="c1"># iframe</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&lt;iframe src=&#39;</span> <span class="o">+</span> <span class="n">url</span> <span class="o">+</span> <span class="s1">&#39;.embed#{} width=750 height=400 frameBorder=&quot;0&quot;&gt;&lt;/iframe&gt;&#39;</span>
-    <span class="k">if</span> <span class="n">text</span><span class="p">:</span>
-        <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;body&gt;</span>
-<span class="s1">        &lt;div class=&quot;textbox&quot;&gt;</span>
-<span class="s1">            &lt;p&gt;Click on the presentation above and use left/right arrow keys to flip through the slides.&lt;/p&gt;</span>
-<span class="s1">        &lt;/div&gt;</span>
-<span class="s1">        &lt;/body&gt;</span>
-<span class="s1">        &#39;&#39;&#39;</span>
-    <span class="k">return</span> <span class="n">html</span>
-
 <span class="n">iframe_5</span> <span class="o">=</span> <span class="n">url_to_iframe</span><span class="p">(</span><span class="n">pres_url_5</span><span class="p">,</span> <span class="bp">True</span><span class="p">)</span>
 <span class="n">IPython</span><span class="o">.</span><span class="n">display</span><span class="o">.</span><span class="n">HTML</span><span class="p">(</span><span class="n">iframe_5</span><span class="p">)</span>
 </pre></div>
@@ -1022,29 +926,6 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">IPython</span>
-
-<span class="k">def</span> <span class="nf">url_to_iframe</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">text</span><span class="o">=</span><span class="bp">True</span><span class="p">):</span>
-    <span class="n">html</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>
-    <span class="c1"># style</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;head&gt;</span>
-<span class="s1">    &lt;style&gt;</span>
-<span class="s1">    div.textbox {</span>
-<span class="s1">        margin: 30px;</span>
-<span class="s1">        font-weight: bold;   </span>
-<span class="s1">    }</span>
-<span class="s1">    &lt;/style&gt;</span>
-<span class="s1">    &lt;/head&gt;&#39;</span>
-<span class="s1">    &#39;&#39;&#39;</span>
-    <span class="c1"># iframe</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&lt;iframe src=&#39;</span> <span class="o">+</span> <span class="n">url</span> <span class="o">+</span> <span class="s1">&#39;.embed#{} width=750 height=400 frameBorder=&quot;0&quot;&gt;&lt;/iframe&gt;&#39;</span>
-    <span class="k">if</span> <span class="n">text</span><span class="p">:</span>
-        <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;body&gt;</span>
-<span class="s1">        &lt;div class=&quot;textbox&quot;&gt;</span>
-<span class="s1">            &lt;p&gt;Click on the presentation above and use left/right arrow keys to flip through the slides.&lt;/p&gt;</span>
-<span class="s1">        &lt;/div&gt;</span>
-<span class="s1">        &lt;/body&gt;</span>
-<span class="s1">        &#39;&#39;&#39;</span>
-    <span class="k">return</span> <span class="n">html</span>
 
 <span class="n">iframe_6</span> <span class="o">=</span> <span class="n">url_to_iframe</span><span class="p">(</span><span class="n">pres_url_6</span><span class="p">,</span> <span class="bp">True</span><span class="p">)</span>
 <span class="n">IPython</span><span class="o">.</span><span class="n">display</span><span class="o">.</span><span class="n">HTML</span><span class="p">(</span><span class="n">iframe_6</span><span class="p">)</span>
@@ -1151,29 +1032,6 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">IPython</span>
-
-<span class="k">def</span> <span class="nf">url_to_iframe</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">text</span><span class="o">=</span><span class="bp">True</span><span class="p">):</span>
-    <span class="n">html</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>
-    <span class="c1"># style</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;head&gt;</span>
-<span class="s1">    &lt;style&gt;</span>
-<span class="s1">    div.textbox {</span>
-<span class="s1">        margin: 30px;</span>
-<span class="s1">        font-weight: bold;   </span>
-<span class="s1">    }</span>
-<span class="s1">    &lt;/style&gt;</span>
-<span class="s1">    &lt;/head&gt;&#39;</span>
-<span class="s1">    &#39;&#39;&#39;</span>
-    <span class="c1"># iframe</span>
-    <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&lt;iframe src=&#39;</span> <span class="o">+</span> <span class="n">url</span> <span class="o">+</span> <span class="s1">&#39;.embed#{} width=750 height=400 frameBorder=&quot;0&quot;&gt;&lt;/iframe&gt;&#39;</span>
-    <span class="k">if</span> <span class="n">text</span><span class="p">:</span>
-        <span class="n">html</span> <span class="o">+=</span> <span class="s1">&#39;&#39;&#39;&lt;body&gt;</span>
-<span class="s1">        &lt;div class=&quot;textbox&quot;&gt;</span>
-<span class="s1">            &lt;p&gt;Click on the presentation above and use left/right arrow keys to flip through the slides.&lt;/p&gt;</span>
-<span class="s1">        &lt;/div&gt;</span>
-<span class="s1">        &lt;/body&gt;</span>
-<span class="s1">        &#39;&#39;&#39;</span>
-    <span class="k">return</span> <span class="n">html</span>
 
 <span class="n">iframe_7</span> <span class="o">=</span> <span class="n">url_to_iframe</span><span class="p">(</span><span class="n">pres_url_7</span><span class="p">,</span> <span class="bp">True</span><span class="p">)</span>
 <span class="n">IPython</span><span class="o">.</span><span class="n">display</span><span class="o">.</span><span class="n">HTML</span><span class="p">(</span><span class="n">iframe_7</span><span class="p">)</span>

--- a/_posts/python/fundamentals/presentations/2015-06-30-presentations-api.html
+++ b/_posts/python/fundamentals/presentations/2015-06-30-presentations-api.html
@@ -1,14 +1,16 @@
 ---
-permalink: python/presentations-api/
+permalink: python/presentations-tool/
 description: How to create and publish a spectacle-presentation with the Python API.
-name: Presentations API | plotly
+name: Presentations Tool | plotly
+has_thumbnail: true
 thumbnail: thumbnail/pres_api.jpg
 layout: user-guide
-name: Presentations API
+name: Presentations Tool
 language: python
-title: Presentations API | plotly
+title: Presentations Tool | plotly
 display_as: file_settings
 has_thumbnail: true
+page_type: u-guide
 order: 0.6
 ---
 {% raw %}
@@ -189,7 +191,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
     <style>
     div.textbox {
         margin: 30px;
-        font-weight: bold;
+        font-weight: bold;   
     }
     </style>
     </head>'
@@ -198,7 +200,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
             <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>
         </div>
         </body>
-
+        
 </div>
 
 </div>
@@ -330,7 +332,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
     <style>
     div.textbox {
         margin: 30px;
-        font-weight: bold;
+        font-weight: bold;   
     }
     </style>
     </head>'
@@ -339,7 +341,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
             <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>
         </div>
         </body>
-
+        
 </div>
 
 </div>
@@ -466,7 +468,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
     <style>
     div.textbox {
         margin: 30px;
-        font-weight: bold;
+        font-weight: bold;   
     }
     </style>
     </head>'
@@ -475,7 +477,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
             <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>
         </div>
         </body>
-
+        
 </div>
 
 </div>
@@ -595,7 +597,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
     <style>
     div.textbox {
         margin: 30px;
-        font-weight: bold;
+        font-weight: bold;   
     }
     </style>
     </head>'
@@ -805,7 +807,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
     <style>
     div.textbox {
         margin: 30px;
-        font-weight: bold;
+        font-weight: bold;   
     }
     </style>
     </head>'
@@ -814,7 +816,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
             <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>
         </div>
         </body>
-
+        
 </div>
 
 </div>
@@ -1014,7 +1016,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
     <style>
     div.textbox {
         margin: 30px;
-        font-weight: bold;
+        font-weight: bold;   
     }
     </style>
     </head>'
@@ -1023,7 +1025,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
             <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>
         </div>
         </body>
-
+        
 </div>
 
 </div>
@@ -1162,7 +1164,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
     <style>
     div.textbox {
         margin: 30px;
-        font-weight: bold;
+        font-weight: bold;   
     }
     </style>
     </head>'
@@ -1171,7 +1173,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
             <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>
         </div>
         </body>
-
+        
 </div>
 
 </div>
@@ -1302,7 +1304,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
     <style>
     div.textbox {
         margin: 30px;
-        font-weight: bold;
+        font-weight: bold;   
     }
     </style>
     </head>'
@@ -1311,7 +1313,7 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
             <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>
         </div>
         </body>
-
+        
 </div>
 
 </div>
@@ -1354,12 +1356,12 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 
 class presentation_ops
  |  Interface to Plotly&#39;s Spectacle-Presentations API.
- |
+ |  
  |  Class methods defined here:
- |
+ |  
  |  upload(cls, presentation, filename, sharing=&#39;public&#39;, auto_open=True) from __builtin__.classobj
  |      Function for uploading presentations to Plotly.
- |
+ |      
  |      :param (dict) presentation: the JSON presentation to be uploaded. Use
  |          plotly.presentation_objs.Presentation to create presentations
  |          from a Markdown-like string.
@@ -1375,7 +1377,7 @@ class presentation_ops
  |          hard to guess, but anyone with the url can view the presentation.
  |      :param (bool) auto_open: automatically opens the presentation in the
  |          browser.
- |
+ |      
  |      See the documentation online for examples.
 
 </pre>
@@ -1386,6 +1388,6 @@ class presentation_ops
 </div>
 
 </div>
-
+ 
 
 {% endraw %}

--- a/_posts/python/fundamentals/presentations/2015-06-30-presentations-api.html
+++ b/_posts/python/fundamentals/presentations/2015-06-30-presentations-api.html
@@ -52,7 +52,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>&#39;2.2.1&#39;</pre>
+<pre>&#39;2.4.1&#39;</pre>
 </div>
 
 </div>
@@ -111,32 +111,21 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 <span class="n">my_pres</span> <span class="o">=</span> <span class="n">pres</span><span class="o">.</span><span class="n">Presentation</span><span class="p">(</span><span class="n">markdown_string</span><span class="p">)</span>
 <span class="n">pres_url_0</span> <span class="o">=</span> <span class="n">py</span><span class="o">.</span><span class="n">presentation_ops</span><span class="o">.</span><span class="n">upload</span><span class="p">(</span><span class="n">my_pres</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-
-<span class="k">print</span><span class="p">(</span><span class="n">pres_url_0</span><span class="p">)</span>
 </pre></div>
 
 </div>
 </div>
 </div>
 
-<div class="output_wrapper">
-<div class="output">
-
-
-<div class="output_area">
-
-<div class="prompt"></div>
-
-
-<div class="output_subarea output_stream output_stdout output_text">
-<pre>https://plot.ly/~AdamKulidjian/3700/simple-pres/
-</pre>
 </div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p><a href="https://plot.ly/~AdamKulidjian/3700/simple-pres/">https://plot.ly/~AdamKulidjian/3700/simple-pres/</a></p>
 
 </div>
 </div>
-
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
@@ -252,32 +241,21 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 
 <span class="n">my_pres</span> <span class="o">=</span> <span class="n">pres</span><span class="o">.</span><span class="n">Presentation</span><span class="p">(</span><span class="n">markdown_string</span><span class="p">)</span>
 <span class="n">pres_url_1</span> <span class="o">=</span> <span class="n">py</span><span class="o">.</span><span class="n">presentation_ops</span><span class="o">.</span><span class="n">upload</span><span class="p">(</span><span class="n">my_pres</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-
-<span class="k">print</span><span class="p">(</span><span class="n">pres_url_1</span><span class="p">)</span>
 </pre></div>
 
 </div>
 </div>
 </div>
 
-<div class="output_wrapper">
-<div class="output">
-
-
-<div class="output_area">
-
-<div class="prompt"></div>
-
-
-<div class="output_subarea output_stream output_stdout output_text">
-<pre>https://plot.ly/~AdamKulidjian/3710/pres-with-plotly-chart/
-</pre>
 </div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p><a href="https://plot.ly/~AdamKulidjian/3710/pres-with-plotly-chart/">https://plot.ly/~AdamKulidjian/3710/pres-with-plotly-chart/</a></p>
 
 </div>
 </div>
-
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
@@ -388,32 +366,21 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 
 <span class="n">my_pres</span> <span class="o">=</span> <span class="n">pres</span><span class="o">.</span><span class="n">Presentation</span><span class="p">(</span><span class="n">markdown_string</span><span class="p">)</span>
 <span class="n">pres_url_2</span> <span class="o">=</span> <span class="n">py</span><span class="o">.</span><span class="n">presentation_ops</span><span class="o">.</span><span class="n">upload</span><span class="p">(</span><span class="n">my_pres</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-
-<span class="k">print</span><span class="p">(</span><span class="n">pres_url_2</span><span class="p">)</span>
 </pre></div>
 
 </div>
 </div>
 </div>
 
-<div class="output_wrapper">
-<div class="output">
-
-
-<div class="output_area">
-
-<div class="prompt"></div>
-
-
-<div class="output_subarea output_stream output_stdout output_text">
-<pre>https://plot.ly/~AdamKulidjian/3702/pres-with-images/
-</pre>
 </div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p><a href="https://plot.ly/~AdamKulidjian/3702/pres-with-images/">https://plot.ly/~AdamKulidjian/3702/pres-with-images/</a></p>
 
 </div>
 </div>
-
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
@@ -517,32 +484,21 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 
 <span class="n">my_pres</span> <span class="o">=</span> <span class="n">pres</span><span class="o">.</span><span class="n">Presentation</span><span class="p">(</span><span class="n">markdown_string</span><span class="p">,</span> <span class="n">imgStretch</span><span class="o">=</span><span class="bp">False</span><span class="p">)</span>
 <span class="n">pres_url_3</span> <span class="o">=</span> <span class="n">py</span><span class="o">.</span><span class="n">presentation_ops</span><span class="o">.</span><span class="n">upload</span><span class="p">(</span><span class="n">my_pres</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-
-<span class="k">print</span><span class="p">(</span><span class="n">pres_url_3</span><span class="p">)</span>
 </pre></div>
 
 </div>
 </div>
 </div>
 
-<div class="output_wrapper">
-<div class="output">
-
-
-<div class="output_area">
-
-<div class="prompt"></div>
-
-
-<div class="output_subarea output_stream output_stdout output_text">
-<pre>https://plot.ly/~AdamKulidjian/3703/pres-with-no-imgstretch/
-</pre>
 </div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p><a href="https://plot.ly/~AdamKulidjian/3703/pres-with-no-imgstretch/">https://plot.ly/~AdamKulidjian/3703/pres-with-no-imgstretch/</a></p>
 
 </div>
 </div>
-
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
@@ -727,32 +683,21 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 
 <span class="n">my_pres</span> <span class="o">=</span> <span class="n">pres</span><span class="o">.</span><span class="n">Presentation</span><span class="p">(</span><span class="n">markdown_string</span><span class="p">)</span>
 <span class="n">pres_url_4</span> <span class="o">=</span> <span class="n">py</span><span class="o">.</span><span class="n">presentation_ops</span><span class="o">.</span><span class="n">upload</span><span class="p">(</span><span class="n">my_pres</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-
-<span class="k">print</span><span class="p">(</span><span class="n">pres_url_4</span><span class="p">)</span>
 </pre></div>
 
 </div>
 </div>
 </div>
 
-<div class="output_wrapper">
-<div class="output">
-
-
-<div class="output_area">
-
-<div class="prompt"></div>
-
-
-<div class="output_subarea output_stream output_stdout output_text">
-<pre>https://plot.ly/~AdamKulidjian/3704/pres-with-code/
-</pre>
 </div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p><a href="https://plot.ly/~AdamKulidjian/3704/pres-with-code/">https://plot.ly/~AdamKulidjian/3704/pres-with-code/</a></p>
 
 </div>
 </div>
-
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
@@ -936,29 +881,9 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 
 <span class="n">my_pres</span> <span class="o">=</span> <span class="n">pres</span><span class="o">.</span><span class="n">Presentation</span><span class="p">(</span><span class="n">markdown_string</span><span class="p">,</span> <span class="n">style</span><span class="o">=</span><span class="s1">&#39;martik&#39;</span><span class="p">)</span>
 <span class="n">pres_url_5</span> <span class="o">=</span> <span class="n">py</span><span class="o">.</span><span class="n">presentation_ops</span><span class="o">.</span><span class="n">upload</span><span class="p">(</span><span class="n">my_pres</span><span class="p">,</span> <span class="s1">&#39;martik-style&#39;</span><span class="p">)</span>
-
-<span class="k">print</span><span class="p">(</span><span class="n">pres_url_5</span><span class="p">)</span>
 </pre></div>
 
 </div>
-</div>
-</div>
-
-<div class="output_wrapper">
-<div class="output">
-
-
-<div class="output_area">
-
-<div class="prompt"></div>
-
-
-<div class="output_subarea output_stream output_stdout output_text">
-<pre>https://plot.ly/~AdamKulidjian/3707/martik-style/
-</pre>
-</div>
-</div>
-
 </div>
 </div>
 
@@ -1084,29 +1009,9 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 
 <span class="n">my_pres</span> <span class="o">=</span> <span class="n">pres</span><span class="o">.</span><span class="n">Presentation</span><span class="p">(</span><span class="n">markdown_string</span><span class="p">,</span> <span class="n">style</span><span class="o">=</span><span class="s1">&#39;moods&#39;</span><span class="p">)</span>
 <span class="n">pres_url_6</span> <span class="o">=</span> <span class="n">py</span><span class="o">.</span><span class="n">presentation_ops</span><span class="o">.</span><span class="n">upload</span><span class="p">(</span><span class="n">my_pres</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-
-<span class="k">print</span><span class="p">(</span><span class="n">pres_url_6</span><span class="p">)</span>
 </pre></div>
 
 </div>
-</div>
-</div>
-
-<div class="output_wrapper">
-<div class="output">
-
-
-<div class="output_area">
-
-<div class="prompt"></div>
-
-
-<div class="output_subarea output_stream output_stdout output_text">
-<pre>https://plot.ly/~AdamKulidjian/3708/pres-with-transitions/
-</pre>
-</div>
-</div>
-
 </div>
 </div>
 
@@ -1224,32 +1129,21 @@ For Plotly charts it is HIGHLY ADVISED that you use a chart that has <code>layou
 <span class="n">my_pres</span><span class="p">[</span><span class="s1">&#39;presentation&#39;</span><span class="p">][</span><span class="s1">&#39;slides&#39;</span><span class="p">][</span><span class="mi">1</span><span class="p">][</span><span class="s1">&#39;children&#39;</span><span class="p">][</span><span class="mi">0</span><span class="p">][</span><span class="s1">&#39;props&#39;</span><span class="p">][</span><span class="s1">&#39;style&#39;</span><span class="p">][</span><span class="s1">&#39;border&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;solid red&#39;</span>
 
 <span class="n">pres_url_7</span> <span class="o">=</span> <span class="n">py</span><span class="o">.</span><span class="n">presentation_ops</span><span class="o">.</span><span class="n">upload</span><span class="p">(</span><span class="n">my_pres</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-
-<span class="k">print</span><span class="p">(</span><span class="n">pres_url_7</span><span class="p">)</span>
 </pre></div>
 
 </div>
 </div>
 </div>
 
-<div class="output_wrapper">
-<div class="output">
-
-
-<div class="output_area">
-
-<div class="prompt"></div>
-
-
-<div class="output_subarea output_stream output_stdout output_text">
-<pre>https://plot.ly/~AdamKulidjian/3709/pres-with-custom-css/
-</pre>
 </div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p><a href="https://plot.ly/~AdamKulidjian/3709/pres-with-custom-css/">https://plot.ly/~AdamKulidjian/3709/pres-with-custom-css/</a></p>
 
 </div>
 </div>
-
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">

--- a/_posts/python/fundamentals/presentations/2018-03-06-presentations.html
+++ b/_posts/python/fundamentals/presentations/2018-03-06-presentations.html
@@ -1,0 +1,5 @@
+---
+permalink: python/presentations-api/
+redirect_to: python/presentations-tool/
+sitemap: false
+---

--- a/_posts/python/fundamentals/presentations/presentations-api.ipynb
+++ b/_posts/python/fundamentals/presentations/presentations-api.ipynb
@@ -60,13 +60,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Display in Jupyter\n",
+    "The function below generates HTML code to display the presentation in an iframe directly in Jupyter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def url_to_iframe(url, text=True):\n",
+    "    html = ''\n",
+    "    # style\n",
+    "    html += '''<head>\n",
+    "    <style>\n",
+    "    div.textbox {\n",
+    "        margin: 30px;\n",
+    "        font-weight: bold;   \n",
+    "    }\n",
+    "    </style>\n",
+    "    </head>'\n",
+    "    '''\n",
+    "    # iframe\n",
+    "    html += '<iframe src=' + url + '.embed#{} width=750 height=400 frameBorder=\"0\"></iframe>'\n",
+    "    if text:\n",
+    "        html += '''<body>\n",
+    "        <div class=\"textbox\">\n",
+    "            <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>\n",
+    "        </div>\n",
+    "        </body>\n",
+    "        '''\n",
+    "    return html"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Simple Example"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
@@ -129,29 +171,6 @@
    "source": [
     "import IPython\n",
     "\n",
-    "def url_to_iframe(url, text=True):\n",
-    "    html = ''\n",
-    "    # style\n",
-    "    html += '''<head>\n",
-    "    <style>\n",
-    "    div.textbox {\n",
-    "        margin: 30px;\n",
-    "        font-weight: bold;   \n",
-    "    }\n",
-    "    </style>\n",
-    "    </head>'\n",
-    "    '''\n",
-    "    # iframe\n",
-    "    html += '<iframe src=' + url + '.embed#{} width=750 height=400 frameBorder=\"0\"></iframe>'\n",
-    "    if text:\n",
-    "        html += '''<body>\n",
-    "        <div class=\"textbox\">\n",
-    "            <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>\n",
-    "        </div>\n",
-    "        </body>\n",
-    "        '''\n",
-    "    return html\n",
-    "\n",
     "iframe_0 = url_to_iframe(pres_url_0, True)\n",
     "IPython.display.HTML(iframe_0)"
    ]
@@ -178,7 +197,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
@@ -248,29 +269,6 @@
    "source": [
     "import IPython\n",
     "\n",
-    "def url_to_iframe(url, text=True):\n",
-    "    html = ''\n",
-    "    # style\n",
-    "    html += '''<head>\n",
-    "    <style>\n",
-    "    div.textbox {\n",
-    "        margin: 30px;\n",
-    "        font-weight: bold;   \n",
-    "    }\n",
-    "    </style>\n",
-    "    </head>'\n",
-    "    '''\n",
-    "    # iframe\n",
-    "    html += '<iframe src=' + url + '.embed#{} width=750 height=400 frameBorder=\"0\"></iframe>'\n",
-    "    if text:\n",
-    "        html += '''<body>\n",
-    "        <div class=\"textbox\">\n",
-    "            <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>\n",
-    "        </div>\n",
-    "        </body>\n",
-    "        '''\n",
-    "    return html\n",
-    "\n",
     "iframe_1 = url_to_iframe(pres_url_1, True)\n",
     "IPython.display.HTML(iframe_1)"
    ]
@@ -286,7 +284,9 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
@@ -357,29 +357,6 @@
    "source": [
     "import IPython\n",
     "\n",
-    "def url_to_iframe(url, text=True):\n",
-    "    html = ''\n",
-    "    # style\n",
-    "    html += '''<head>\n",
-    "    <style>\n",
-    "    div.textbox {\n",
-    "        margin: 30px;\n",
-    "        font-weight: bold;   \n",
-    "    }\n",
-    "    </style>\n",
-    "    </head>'\n",
-    "    '''\n",
-    "    # iframe\n",
-    "    html += '<iframe src=' + url + '.embed#{} width=750 height=400 frameBorder=\"0\"></iframe>'\n",
-    "    if text:\n",
-    "        html += '''<body>\n",
-    "        <div class=\"textbox\">\n",
-    "            <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>\n",
-    "        </div>\n",
-    "        </body>\n",
-    "        '''\n",
-    "    return html\n",
-    "\n",
     "iframe_2 = url_to_iframe(pres_url_2, True)\n",
     "IPython.display.HTML(iframe_2)"
    ]
@@ -395,7 +372,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
@@ -411,7 +390,6 @@
     "Image(https://raw.githubusercontent.com/jackparmer/gradient-backgrounds/master/moods1.png)\n",
     "Image(https://raw.githubusercontent.com/jackparmer/gradient-backgrounds/master/moods1.png)\n",
     "\"\"\"\n",
-    "\n",
     "\n",
     "my_pres = pres.Presentation(markdown_string, imgStretch=False)\n",
     "pres_url_3 = py.presentation_ops.upload(my_pres, filename)"
@@ -456,29 +434,6 @@
    "source": [
     "import IPython\n",
     "\n",
-    "def url_to_iframe(url, text=True):\n",
-    "    html = ''\n",
-    "    # style\n",
-    "    html += '''<head>\n",
-    "    <style>\n",
-    "    div.textbox {\n",
-    "        margin: 30px;\n",
-    "        font-weight: bold;   \n",
-    "    }\n",
-    "    </style>\n",
-    "    </head>'\n",
-    "    '''\n",
-    "    # iframe\n",
-    "    html += '<iframe src=' + url + '.embed#{} width=750 height=400 frameBorder=\"0\"></iframe>'\n",
-    "    if text:\n",
-    "        html += '''<body>\n",
-    "        <div class=\"textbox\">\n",
-    "            <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>\n",
-    "        </div>\n",
-    "        </body>\n",
-    "        '''\n",
-    "    return html\n",
-    "\n",
     "iframe_3 = url_to_iframe(pres_url_3, False)\n",
     "IPython.display.HTML(iframe_3)"
    ]
@@ -503,7 +458,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
@@ -647,29 +604,6 @@
    "source": [
     "import IPython\n",
     "\n",
-    "def url_to_iframe(url, text=True):\n",
-    "    html = ''\n",
-    "    # style\n",
-    "    html += '''<head>\n",
-    "    <style>\n",
-    "    div.textbox {\n",
-    "        margin: 30px;\n",
-    "        font-weight: bold;   \n",
-    "    }\n",
-    "    </style>\n",
-    "    </head>'\n",
-    "    '''\n",
-    "    # iframe\n",
-    "    html += '<iframe src=' + url + '.embed#{} width=750 height=400 frameBorder=\"0\"></iframe>'\n",
-    "    if text:\n",
-    "        html += '''<body>\n",
-    "        <div class=\"textbox\">\n",
-    "            <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>\n",
-    "        </div>\n",
-    "        </body>\n",
-    "        '''\n",
-    "    return html\n",
-    "\n",
     "iframe_4 = url_to_iframe(pres_url_4, True)\n",
     "IPython.display.HTML(iframe_4)"
    ]
@@ -685,7 +619,9 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
@@ -822,29 +758,6 @@
    "source": [
     "import IPython\n",
     "\n",
-    "def url_to_iframe(url, text=True):\n",
-    "    html = ''\n",
-    "    # style\n",
-    "    html += '''<head>\n",
-    "    <style>\n",
-    "    div.textbox {\n",
-    "        margin: 30px;\n",
-    "        font-weight: bold;   \n",
-    "    }\n",
-    "    </style>\n",
-    "    </head>'\n",
-    "    '''\n",
-    "    # iframe\n",
-    "    html += '<iframe src=' + url + '.embed#{} width=750 height=400 frameBorder=\"0\"></iframe>'\n",
-    "    if text:\n",
-    "        html += '''<body>\n",
-    "        <div class=\"textbox\">\n",
-    "            <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>\n",
-    "        </div>\n",
-    "        </body>\n",
-    "        '''\n",
-    "    return html\n",
-    "\n",
     "iframe_5 = url_to_iframe(pres_url_5, True)\n",
     "IPython.display.HTML(iframe_5)"
    ]
@@ -871,7 +784,9 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
@@ -941,29 +856,6 @@
    "source": [
     "import IPython\n",
     "\n",
-    "def url_to_iframe(url, text=True):\n",
-    "    html = ''\n",
-    "    # style\n",
-    "    html += '''<head>\n",
-    "    <style>\n",
-    "    div.textbox {\n",
-    "        margin: 30px;\n",
-    "        font-weight: bold;   \n",
-    "    }\n",
-    "    </style>\n",
-    "    </head>'\n",
-    "    '''\n",
-    "    # iframe\n",
-    "    html += '<iframe src=' + url + '.embed#{} width=750 height=400 frameBorder=\"0\"></iframe>'\n",
-    "    if text:\n",
-    "        html += '''<body>\n",
-    "        <div class=\"textbox\">\n",
-    "            <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>\n",
-    "        </div>\n",
-    "        </body>\n",
-    "        '''\n",
-    "    return html\n",
-    "\n",
     "iframe_6 = url_to_iframe(pres_url_6, True)\n",
     "IPython.display.HTML(iframe_6)"
    ]
@@ -979,7 +871,9 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
@@ -1054,29 +948,6 @@
    "source": [
     "import IPython\n",
     "\n",
-    "def url_to_iframe(url, text=True):\n",
-    "    html = ''\n",
-    "    # style\n",
-    "    html += '''<head>\n",
-    "    <style>\n",
-    "    div.textbox {\n",
-    "        margin: 30px;\n",
-    "        font-weight: bold;   \n",
-    "    }\n",
-    "    </style>\n",
-    "    </head>'\n",
-    "    '''\n",
-    "    # iframe\n",
-    "    html += '<iframe src=' + url + '.embed#{} width=750 height=400 frameBorder=\"0\"></iframe>'\n",
-    "    if text:\n",
-    "        html += '''<body>\n",
-    "        <div class=\"textbox\">\n",
-    "            <p>Click on the presentation above and use left/right arrow keys to flip through the slides.</p>\n",
-    "        </div>\n",
-    "        </body>\n",
-    "        '''\n",
-    "    return html\n",
-    "\n",
     "iframe_7 = url_to_iframe(pres_url_7, True)\n",
     "IPython.display.HTML(iframe_7)"
    ]
@@ -1134,7 +1005,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -1166,7 +1037,7 @@
      "output_type": "stream",
      "text": [
       "Collecting git+https://github.com/plotly/publisher.git\n",
-      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-0Lee24-build\n",
+      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-qxJ5r5-build\n",
       "Installing collected packages: publisher\n",
       "  Found existing installation: publisher 0.11\n",
       "    Uninstalling publisher-0.11:\n",
@@ -1179,14 +1050,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning:\n",
-      "\n",
-      "The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
-      "\n",
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning:\n",
-      "\n",
-      "Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
-      "\n"
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning: The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
+      "  \"You should import from nbconvert instead.\", ShimWarning)\n",
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning: Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
+      "  warnings.warn('Did you \"Save\" this notebook before running this command? '\n"
      ]
     }
    ],

--- a/_posts/python/fundamentals/presentations/presentations-api.ipynb
+++ b/_posts/python/fundamentals/presentations/presentations-api.ipynb
@@ -1172,7 +1172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -1204,27 +1204,23 @@
      "output_type": "stream",
      "text": [
       "Collecting git+https://github.com/plotly/publisher.git\n",
-      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-WgNprc-build\n",
+      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-3kJjU1-build\n",
       "Installing collected packages: publisher\n",
-      "  Found existing installation: publisher 0.10\n",
-      "    Uninstalling publisher-0.10:\n",
-      "      Successfully uninstalled publisher-0.10\n",
+      "  Found existing installation: publisher 0.11\n",
+      "    Uninstalling publisher-0.11:\n",
+      "      Successfully uninstalled publisher-0.11\n",
       "  Running setup.py install for publisher ... \u001b[?25ldone\n",
-      "\u001b[?25hSuccessfully installed publisher-0.10\n"
+      "\u001b[?25hSuccessfully installed publisher-0.11\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning:\n",
-      "\n",
-      "The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
-      "\n",
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning:\n",
-      "\n",
-      "Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
-      "\n"
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning: The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
+      "  \"You should import from nbconvert instead.\", ShimWarning)\n",
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning: Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
+      "  warnings.warn('Did you \"Save\" this notebook before running this command? '\n"
      ]
     }
    ],
@@ -1237,10 +1233,10 @@
     "!pip install git+https://github.com/plotly/publisher.git --upgrade\n",
     "import publisher\n",
     "publisher.publish(\n",
-    "    'presentations-api.ipynb', 'python/presentations-api/', 'Presentations API | plotly',\n",
+    "    'presentations-api.ipynb', 'python/presentations-tool/', 'Presentations Tool | plotly',\n",
     "    'How to create and publish a spectacle-presentation with the Python API.',\n",
-    "    title = 'Presentations API | plotly',\n",
-    "    name = 'Presentations API',\n",
+    "    title = 'Presentations Tool | plotly',\n",
+    "    name = 'Presentations Tool',\n",
     "    thumbnail='thumbnail/pres_api.jpg', language='python',\n",
     "    has_thumbnail='true', display_as='file_settings', order=0.6)"
    ]
@@ -1272,7 +1268,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/_posts/python/fundamentals/presentations/presentations-api.ipynb
+++ b/_posts/python/fundamentals/presentations/presentations-api.ipynb
@@ -21,7 +21,7 @@
     {
      "data": {
       "text/plain": [
-       "'2.2.1'"
+       "'2.4.1'"
       ]
      },
      "execution_count": 1,
@@ -67,15 +67,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://plot.ly/~AdamKulidjian/3700/simple-pres/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
     "import plotly.presentation_objs as pres\n",
@@ -92,9 +84,14 @@
     "\"\"\"\n",
     "\n",
     "my_pres = pres.Presentation(markdown_string)\n",
-    "pres_url_0 = py.presentation_ops.upload(my_pres, filename)\n",
-    "\n",
-    "print(pres_url_0)"
+    "pres_url_0 = py.presentation_ops.upload(my_pres, filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "https://plot.ly/~AdamKulidjian/3700/simple-pres/"
    ]
   },
   {
@@ -182,15 +179,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://plot.ly/~AdamKulidjian/3710/pres-with-plotly-chart/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
     "import plotly.presentation_objs as pres\n",
@@ -214,9 +203,14 @@
     "\"\"\"\n",
     "\n",
     "my_pres = pres.Presentation(markdown_string)\n",
-    "pres_url_1 = py.presentation_ops.upload(my_pres, filename)\n",
-    "\n",
-    "print(pres_url_1)"
+    "pres_url_1 = py.presentation_ops.upload(my_pres, filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "https://plot.ly/~AdamKulidjian/3710/pres-with-plotly-chart/"
    ]
   },
   {
@@ -293,15 +287,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://plot.ly/~AdamKulidjian/3702/pres-with-images/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
     "import plotly.presentation_objs as pres\n",
@@ -326,9 +312,14 @@
     "\"\"\"\n",
     "\n",
     "my_pres = pres.Presentation(markdown_string)\n",
-    "pres_url_2 = py.presentation_ops.upload(my_pres, filename)\n",
-    "\n",
-    "print(pres_url_2)"
+    "pres_url_2 = py.presentation_ops.upload(my_pres, filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "https://plot.ly/~AdamKulidjian/3702/pres-with-images/"
    ]
   },
   {
@@ -405,15 +396,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://plot.ly/~AdamKulidjian/3703/pres-with-no-imgstretch/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
     "import plotly.presentation_objs as pres\n",
@@ -431,9 +414,14 @@
     "\n",
     "\n",
     "my_pres = pres.Presentation(markdown_string, imgStretch=False)\n",
-    "pres_url_3 = py.presentation_ops.upload(my_pres, filename)\n",
-    "\n",
-    "print(pres_url_3)"
+    "pres_url_3 = py.presentation_ops.upload(my_pres, filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "https://plot.ly/~AdamKulidjian/3703/pres-with-no-imgstretch/"
    ]
   },
   {
@@ -516,15 +504,7 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://plot.ly/~AdamKulidjian/3704/pres-with-code/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
     "import plotly.presentation_objs as pres\n",
@@ -622,9 +602,14 @@
     "\"\"\"\n",
     "\n",
     "my_pres = pres.Presentation(markdown_string)\n",
-    "pres_url_4 = py.presentation_ops.upload(my_pres, filename)\n",
-    "\n",
-    "print(pres_url_4)"
+    "pres_url_4 = py.presentation_ops.upload(my_pres, filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "https://plot.ly/~AdamKulidjian/3704/pres-with-code/"
    ]
   },
   {
@@ -701,15 +686,7 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://plot.ly/~AdamKulidjian/3707/martik-style/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
     "import plotly.presentation_objs as pres\n",
@@ -807,9 +784,7 @@
     "\"\"\"\n",
     "\n",
     "my_pres = pres.Presentation(markdown_string, style='martik')\n",
-    "pres_url_5 = py.presentation_ops.upload(my_pres, 'martik-style')\n",
-    "\n",
-    "print(pres_url_5)"
+    "pres_url_5 = py.presentation_ops.upload(my_pres, 'martik-style')"
    ]
   },
   {
@@ -897,15 +872,7 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://plot.ly/~AdamKulidjian/3708/pres-with-transitions/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
     "import plotly.presentation_objs as pres\n",
@@ -936,9 +903,7 @@
     "\"\"\"\n",
     "\n",
     "my_pres = pres.Presentation(markdown_string, style='moods')\n",
-    "pres_url_6 = py.presentation_ops.upload(my_pres, filename)\n",
-    "\n",
-    "print(pres_url_6)"
+    "pres_url_6 = py.presentation_ops.upload(my_pres, filename)"
    ]
   },
   {
@@ -1015,15 +980,7 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://plot.ly/~AdamKulidjian/3709/pres-with-custom-css/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import plotly.plotly as py\n",
     "import plotly.presentation_objs as pres\n",
@@ -1052,9 +1009,14 @@
     "# change text border style\n",
     "my_pres['presentation']['slides'][1]['children'][0]['props']['style']['border'] = 'solid red'\n",
     "\n",
-    "pres_url_7 = py.presentation_ops.upload(my_pres, filename)\n",
-    "\n",
-    "print(pres_url_7)"
+    "pres_url_7 = py.presentation_ops.upload(my_pres, filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "https://plot.ly/~AdamKulidjian/3709/pres-with-custom-css/"
    ]
   },
   {
@@ -1172,7 +1134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1204,7 +1166,7 @@
      "output_type": "stream",
      "text": [
       "Collecting git+https://github.com/plotly/publisher.git\n",
-      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-3kJjU1-build\n",
+      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-0Lee24-build\n",
       "Installing collected packages: publisher\n",
       "  Found existing installation: publisher 0.11\n",
       "    Uninstalling publisher-0.11:\n",
@@ -1217,10 +1179,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning: The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
-      "  \"You should import from nbconvert instead.\", ShimWarning)\n",
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning: Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
-      "  warnings.warn('Did you \"Save\" this notebook before running this command? '\n"
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning:\n",
+      "\n",
+      "The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
+      "\n",
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning:\n",
+      "\n",
+      "Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
+      "\n"
      ]
     }
    ],

--- a/_posts/python/maps/county-choropleth/2015-06-30-county_choropleth.html
+++ b/_posts/python/maps/county-choropleth/2015-06-30-county_choropleth.html
@@ -496,6 +496,15 @@ Default for both <code>simplify_county</code> and <code>simplif_state</code> is 
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
+<p>Also see Mapbox county choropleths made in Python: <a href="https://plot.ly/python/county-choropleth/">https://plot.ly/python/county-choropleth/</a></p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
 <h4 id="Reference">Reference<a class="anchor-link" href="#Reference">&#194;&#182;</a></h4><p>Note: the param <code>offline_mode</code> will be renamed in a future version of Plotly. Enabling <em>does</em> activate the <code>unselected</code> and <code>selected</code> features of the centroid scatter points but since these features exist in Plotly Reference Library, <code>offline_mode</code> can be set to <code>True</code> and run in online mode.</p>
 <p>See <a href="https://plot.ly/python/reference/#scatter-selected">https://plot.ly/python/reference/#scatter-selected</a> and <a href="https://plot.ly/python/reference/#scatter-unselected">https://plot.ly/python/reference/#scatter-unselected</a></p>
 

--- a/_posts/python/maps/county-choropleth/2015-06-30-county_choropleth.html
+++ b/_posts/python/maps/county-choropleth/2015-06-30-county_choropleth.html
@@ -496,7 +496,7 @@ Default for both <code>simplify_county</code> and <code>simplif_state</code> is 
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Also see Mapbox county choropleths made in Python: <a href="https://plot.ly/python/county-choropleth/">https://plot.ly/python/county-choropleth/</a></p>
+<p>Also see Mapbox county choropleths made in Python: <a href="https://plot.ly/python/mapbox-county-choropleth/">https://plot.ly/python/mapbox-county-choropleth/</a></p>
 
 </div>
 </div>

--- a/_posts/python/maps/county-choropleth/county_choropleth.ipynb
+++ b/_posts/python/maps/county-choropleth/county_choropleth.ipynb
@@ -409,6 +409,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Also see Mapbox county choropleths made in Python: https://plot.ly/python/county-choropleth/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Reference\n",
     "Note: the param `offline_mode` will be renamed in a future version of Plotly. Enabling _does_ activate the `unselected` and `selected` features of the centroid scatter points but since these features exist in Plotly Reference Library, `offline_mode` can be set to `True` and run in online mode.\n",
     "\n",
@@ -671,7 +678,7 @@
      "output_type": "stream",
      "text": [
       "Collecting git+https://github.com/plotly/publisher.git\n",
-      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-9qabVC-build\n",
+      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-YtZVzc-build\n",
       "Installing collected packages: publisher\n",
       "  Found existing installation: publisher 0.11\n",
       "    Uninstalling publisher-0.11:\n",

--- a/_posts/python/maps/county-choropleth/county_choropleth.ipynb
+++ b/_posts/python/maps/county-choropleth/county_choropleth.ipynb
@@ -409,7 +409,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Also see Mapbox county choropleths made in Python: https://plot.ly/python/county-choropleth/"
+    "Also see Mapbox county choropleths made in Python: [https://plot.ly/python/mapbox-county-choropleth/](https://plot.ly/python/mapbox-county-choropleth/)"
    ]
   },
   {
@@ -646,7 +646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -678,7 +678,7 @@
      "output_type": "stream",
      "text": [
       "Collecting git+https://github.com/plotly/publisher.git\n",
-      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-YtZVzc-build\n",
+      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-dtAL8P-build\n",
       "Installing collected packages: publisher\n",
       "  Found existing installation: publisher 0.11\n",
       "    Uninstalling publisher-0.11:\n",
@@ -691,14 +691,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning:\n",
-      "\n",
-      "The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
-      "\n",
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning:\n",
-      "\n",
-      "Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
-      "\n"
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning: The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
+      "  \"You should import from nbconvert instead.\", ShimWarning)\n",
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning: Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
+      "  warnings.warn('Did you \"Save\" this notebook before running this command? '\n"
      ]
     }
    ],

--- a/_posts/python/maps/mapbox-county-choropleth/2015-06-30-mapbox-county-choropleth.html
+++ b/_posts/python/maps/mapbox-county-choropleth/2015-06-30-mapbox-county-choropleth.html
@@ -1,5 +1,5 @@
 ---
-permalink: python/mapbox-county-choropleth
+permalink: python/mapbox-county-choropleth/
 description: How to make a Mapbox Choropleth Map of the Florida Counties in Python with Plotly.
 name: Python Mapbox Choropleth Maps | plotly
 has_thumbnail: true

--- a/_posts/python/maps/mapbox-county-choropleth/mapbox-county-choropleth.ipynb
+++ b/_posts/python/maps/mapbox-county-choropleth/mapbox-county-choropleth.ipynb
@@ -291,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -322,10 +322,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning: The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
-      "  \"You should import from nbconvert instead.\", ShimWarning)\n",
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning: Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
-      "  warnings.warn('Did you \"Save\" this notebook before running this command? '\n"
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning:\n",
+      "\n",
+      "The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
+      "\n",
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning:\n",
+      "\n",
+      "Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
+      "\n"
      ]
     }
    ],
@@ -337,7 +341,7 @@
     "\n",
     "import publisher\n",
     "publisher.publish(\n",
-    "    'mapbox-county-choropleth.ipynb', 'python/mapbox-county-choropleth', 'Python Mapbox Choropleth Maps | plotly',\n",
+    "    'mapbox-county-choropleth.ipynb', 'python/mapbox-county-choropleth/', 'Python Mapbox Choropleth Maps | plotly',\n",
     "    'How to make a Mapbox Choropleth Map of the Florida Counties in Python with Plotly.',\n",
     "    title='Python Mapbox Choropleth Maps | plotly',\n",
     "    name='Mapbox Choropleth Maps',\n",


### PR DESCRIPTION
few tasks:
- [x] Redirect `https://plot.ly/python/presentations-api/` to `https://plot.ly/python/presentations-tool/` and rename the header/title “Python Presentations Tool”
- [x] Getting a 404 for mapbox county choropleths
- [x] https://plot.ly/python/county-choropleth/ needs to have a link to the Mapbox county level choropleths at the bottom. (Say something like, “Also see Mapbox county choropleths made in Python”)