### PR TITLE
update main signup link from /ssu to new /api_signup

### DIFF
--- a/_includes/python-getting-started.html
+++ b/_includes/python-getting-started.html
@@ -73,7 +73,7 @@ plotly.offline.iplot({
         <h4>Hosting on Plotly</h4>
 
         <p>
-            Plotly provides a web-service for hosting graphs. <a href="https://plot.ly/ssu">Create a free account</a> to get started.
+            Plotly provides a web-service for hosting graphs. <a href="https://plot.ly/api_signup">Create a free account</a> to get started.
             Graphs are saved inside your online Plotly account and you control the privacy. Public hosting is free, for private hosting, check out our <a href="https://plot.ly/products/cloud">paid plans</a>.
         </p>
 

--- a/_posts/ggplot2/2015-08-10-getting-started_ggplot2_index.Rmd
+++ b/_posts/ggplot2/2015-08-10-getting-started_ggplot2_index.Rmd
@@ -70,7 +70,7 @@ Plotly graphs are interactive. Click on legend entries to toggle traces, click-a
 
 You can publish your charts to the web with Plotly's web service.
 
-1 - [Create a free Plotly account](https://plot.ly/ssu):<br>
+1 - [Create a free Plotly account](https://plot.ly/api_signup):<br>
 A Plotly account is required to publish charts online. It's free to get started, and you control the privacy of your charts.
 
 2 - Save your authentication credentials<br>

--- a/_posts/ggplot2/2015-08-10-getting-started_ggplot2_index.md
+++ b/_posts/ggplot2/2015-08-10-getting-started_ggplot2_index.md
@@ -66,7 +66,7 @@ Plotly graphs are interactive. Click on legend entries to toggle traces, click-a
 
 You can publish your charts to the web with Plotly's web service.
 
-1 - [Create a free Plotly account](https://plot.ly/ssu):<br>
+1 - [Create a free Plotly account](https://plot.ly/api_signup):<br>
 A Plotly account is required to publish charts online. It's free to get started, and you control the privacy of your charts.
 
 2 - Save your authentication credentials<br>

--- a/_posts/python/getting-started/2015-06-30-getting-started.html
+++ b/_posts/python/getting-started/2015-06-30-getting-started.html
@@ -47,7 +47,7 @@ Plotly's Python package is <a href="https://github.com/plotly/plotly.py/blob/mas
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h3 id="Initialization-for-Online-Plotting">Initialization for Online Plotting<a class="anchor-link" href="#Initialization-for-Online-Plotting">&#182;</a></h3><p>Plotly provides a web-service for hosting graphs! Create a <a href="https://plot.ly/ssu/">free account</a> to get started. Graphs are saved inside your online Plotly account and you control the privacy. Public hosting is free, for private hosting, check out our <a href="https://plot.ly/products/cloud/">paid plans</a>.
+<h3 id="Initialization-for-Online-Plotting">Initialization for Online Plotting<a class="anchor-link" href="#Initialization-for-Online-Plotting">&#182;</a></h3><p>Plotly provides a web-service for hosting graphs! Create a <a href="https://plot.ly/api_signup">free account</a> to get started. Graphs are saved inside your online Plotly account and you control the privacy. Public hosting is free, for private hosting, check out our <a href="https://plot.ly/products/cloud/">paid plans</a>.
 <br>
 <br>
 After installing the Plotly package, you're ready to fire up python:

--- a/_posts/python/getting-started/getting-started.ipynb
+++ b/_posts/python/getting-started/getting-started.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "source": [
     "### Initialization for Online Plotting\n",
-    "Plotly provides a web-service for hosting graphs! Create a [free account](https://plot.ly/ssu/) to get started. Graphs are saved inside your online Plotly account and you control the privacy. Public hosting is free, for private hosting, check out our [paid plans](https://plot.ly/products/cloud/).\n",
+    "Plotly provides a web-service for hosting graphs! Create a [free account](https://plot.ly/api_signup) to get started. Graphs are saved inside your online Plotly account and you control the privacy. Public hosting is free, for private hosting, check out our [paid plans](https://plot.ly/products/cloud/).\n",
     "<br>\n",
     "<br>\n",
     "After installing the Plotly package, you're ready to fire up python:\n",

--- a/_posts/r/2015-07-30-getting-started.md
+++ b/_posts/r/2015-07-30-getting-started.md
@@ -51,7 +51,7 @@ Plotly graphs are interactive. Click on legend entries to toggle traces, click-a
 
 You can publish your charts to the web with Plotly's web service.
 
-1 - [Create a free Plotly account](https://plot.ly/ssu):<br>
+1 - [Create a free Plotly account](https://plot.ly/api_signup):<br>
 A Plotly account is required to publish charts online. It's free to get started, and you control the privacy of your charts.
 
 2 - Save your authentication credentials<br>

--- a/_posts/scala/2016-03-22-getting-started.md
+++ b/_posts/scala/2016-03-22-getting-started.md
@@ -25,7 +25,7 @@ If you need documentation beyond the tutorials presented here, read either the [
 
 The Scala Plotly client looks for credentials placed in a file called `~/.plotly/.credentials`. If you have already used another Plotly client, for instance the Python client, you probably have this file already and you do not need to do anything else.
 
-Otherwise, start by [creating a free account](https://plot.ly/ssu) on Plotly to get started. Graphs are saved inside your Plotly account and you control the privacy. Public hosting is free. For private hosting, you can use one of the [paid plans](https://plot.ly/products/cloud).
+Otherwise, start by [creating a free account](https://plot.ly/api_signup) on Plotly to get started. Graphs are saved inside your Plotly account and you control the privacy. Public hosting is free. For private hosting, you can use one of the [paid plans](https://plot.ly/products/cloud).
 
 Once you have an account, generate an [API key](https://plot.ly/settings/api/). Copy the key and create the file `~/.plotly/.credentials` with the following content, replacing the username and API key with your own:
 


### PR DESCRIPTION
I've created a new landing URL for developer signups at https://plot.ly/api_signup which redirects to https://plot.ly/accounts/login/?action=signup&next=%2Fsettings%2Fapi#/ which pops up the Sign Up modal and on signup redirects to /settings/api so they can get their API key right away, and that page now contains links back to Getting Started so that they can configure their .credentials.

This PR updates all links to this new URL from https://plot.ly/ssu which has redirected to /feed for the past 9 months :)