### PR TITLE
exclude 'info_array' attrs from extra-info-about "items" block

### DIFF
--- a/_includes/reference-block.html
+++ b/_includes/reference-block.html
@@ -110,7 +110,7 @@
                 {% endif %}
             {% endif %}
 
-            {% if obj[1].items %}
+            {% if obj[1].items and obj[1].valType != "info_array" %}
                 <br>Each {% raw %}{object}{% endraw %} has one or more of the keys listed below.
                 {% if obj[0] == "annotations" %}
                     {% unless obj[1].description %}


### PR DESCRIPTION
Currently, 'info_array' attributes have an erroneous _Each object has one or more of the keys listed below_ line e.g. for axis ranges:


![image](https://user-images.githubusercontent.com/6675409/42291005-e3435bd2-7f96-11e8-8509-0f69969cc59b.png)

with this patch, we now have:

![image](https://user-images.githubusercontent.com/6675409/42291024-06d36cf4-7f97-11e8-9264-f98a69b71bf1.png)


cc @cldougl @nicolaskruchten 
