### PR TITLE
fix bug in showexponent

### DIFF
--- a/_posts/plotly_js/layout/axes/2015-04-09-axes-labels.html
+++ b/_posts/plotly_js/layout/axes/2015-04-09-axes-labels.html
@@ -7,14 +7,16 @@ order: 0
 sitemap: false
 arrangement: horizontal
 ---
+var x = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+var maxX = Math.max(...x);
 var trace1 = {
-  x: [0, 1, 2, 3, 4, 5, 6, 7, 8],
-  y: [8, 7, 6, 5, 4, 3, 2, 1, 0],
+  x: x,
+  y: x.map(x => maxX-x).map(x => x*1E10),
   type: 'scatter'
 };
 var trace2 = {
-  x: [0, 1, 2, 3, 4, 5, 6, 7, 8],
-  y: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+  x: x,
+  y: x.map(x => x*1E10),
   type: 'scatter'
 };
 var data = [trace1, trace2];
@@ -34,7 +36,7 @@ var layout = {
       color: 'black'
     },
     exponentformat: 'e',
-    showexponent: 'All'
+    showexponent: 'all'
   },
   yaxis: {
     title: 'AXIS TITLE',
@@ -51,7 +53,7 @@ var layout = {
       color: 'black'
     },
     exponentformat: 'e',
-    showexponent: 'All'
+    showexponent: 'all'
   }
 };
 Plotly.newPlot('myDiv', data, layout);


### PR DESCRIPTION
fixed case in 'All' to 'all' for showexponent attribute. from [this issue](https://github.com/plotly/documentation/issues/969) @cldougl @bcdunbar 