### PR TITLE
temp IE fix

### DIFF
--- a/all_static/css/main.css
+++ b/all_static/css/main.css
@@ -30,7 +30,7 @@ body {
     -webkit-box-flex: 1;
     -webkit-flex: 1;
     -ms-flex: 1;
-    flex: 1;
+    flex: auto;
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1865,7 +1865,7 @@ ul.\--ref {
   -webkit-box-flex: 0;
   -webkit-flex: 0;
   -ms-flex: 0;
-  flex: 0;
+  flex: auto;
   width: 100%;
   position: relative;
   z-index: 99;
@@ -8337,7 +8337,8 @@ pre, code, .hljs {
     -webkit-box-flex: 1;
     -webkit-flex: 1 1 -webkit-calc(162px);
     -ms-flex: 1 1 calc(162px);
-    flex: 1 1 calc(162px);
+    /* flex: 1 1 calc(162px); */
+    flex: auto;
     width: -webkit-calc(162px - 20px);
     width: calc(162px - 20px);
     max-width: 162px;
@@ -8351,7 +8352,8 @@ pre, code, .hljs {
         -webkit-box-flex: 1;
         -webkit-flex: 1 1 -webkit-calc(162px);
         -ms-flex: 1 1 calc(162px);
-        flex: 1 1 calc(162px);
+        /* flex: 1 1 calc(162px); */
+        flex: auto;
         width: -webkit-calc(162px);
         width: calc(162px);
         max-width: -webkit-calc(162px);


### PR DESCRIPTION
This addresses https://github.com/plotly/documentation/issues/502

@cldougl this is a temp fix which ought to deal with the potential IE flexbox issues https://caniuse.com/#feat=flexbox My whole dev env is on the fritz today and I couldn't get gulp working on windows, thus I directly edited main.css for now (instead of the below scss files and gulp build).

For reference, scss files that will need changed (when I get things working again).

_components/_base.scss https://github.com/plotly/documentation/blob/source-design-merge/scss/_components/_base.scss#L36

_components/_helpbox.scss https://github.com/plotly/documentation/blob/source-design-merge/scss/_components/_helpbox.scss#L5

layout/layout.grid.scss https://github.com/plotly/documentation/blob/source-design-merge/scss/layout/layout.grid.scss#L31
