### PR TITLE
Update Gemfile algoliasearch-jekyll -> jekyll-algolia

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ group :jekyll_plugins do
 end
 
 group :jekyll_plugins do
-  gem 'algoliasearch-jekyll', '~> 0.8.2'
+  gem 'jekyll-algolia', '~> 1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,21 +8,12 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    algoliasearch (1.15.1)
-      httpclient (~> 2.8.3)
+    algolia_html_extractor (2.6.1)
+      json (~> 2.0)
+      nokogiri (~> 1.8.2)
+    algoliasearch (1.23.2)
+      httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
-    algoliasearch-jekyll (0.8.2)
-      algoliasearch (~> 1.4)
-      appraisal (~> 2.1.0)
-      awesome_print (~> 1.6)
-      json (>= 1.8.6)
-      nokogiri (~> 1.7, >= 1.7.2)
-      verbal_expressions (~> 0.1.5)
-    appraisal (2.1.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
-    awesome_print (1.8.0)
     byebug (9.0.6)
     coderay (1.1.1)
     coffee-script (2.4.1)
@@ -38,6 +29,7 @@ GEM
     ffi (1.9.18)
     ffi (1.9.18-x64-mingw32)
     ffi (1.9.18-x86-mingw32)
+    filesize (0.1.1)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
     github-pages (139)
@@ -104,6 +96,15 @@ GEM
       pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
+    jekyll-algolia (1.4.6)
+      algolia_html_extractor (~> 2.6)
+      algoliasearch (~> 1.18)
+      filesize (~> 0.1)
+      jekyll (~> 3.0)
+      json (~> 2.0)
+      nokogiri (~> 1.6)
+      progressbar (~> 1.9)
+      verbal_expressions (~> 0.1.5)
     jekyll-avatar (0.4.2)
       jekyll (~> 3.0)
     jekyll-coffeescript (1.0.1)
@@ -213,6 +214,7 @@ GEM
       jekyll (>= 2.0)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
+    progressbar (1.9.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -235,7 +237,6 @@ GEM
     slop (3.6.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thor (0.20.0)
     thread_safe (0.3.6)
     titlecase (0.1.1)
     typhoeus (0.8.0)
@@ -251,8 +252,8 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
-  algoliasearch-jekyll (~> 0.8.2)
   github-pages
+  jekyll-algolia (~> 1.0)
   jekyll-redirect-from
   jekyll-sitemap
   jemoji

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,7 +1,7 @@
 gems:
 - jekyll-redirect-from
 - jekyll-sitemap
-- algoliasearch-jekyll
+- jekyll-algolia
 
 # ---
 # Define URLs


### PR DESCRIPTION
`algoliasearch-jekyll` DEPRECATED. 

The following error appears because of it 
![bundle_install_issue](https://user-images.githubusercontent.com/25846124/43269038-00f76a94-90c0-11e8-82e1-a54fe41b1af5.PNG)

Updated the Gemfile now with `jekyll-algolia`