### PR TITLE
added display_as text to breadcrumbs

### DIFF
--- a/_data/display_as.yml
+++ b/_data/display_as.yml
@@ -11,28 +11,28 @@ signal-analysis:
     reference: '#signal-analysis'
     text: Signal Analysis
 file_settings:
-    reference: '#fundamentals'
+    reference: 'plotly-fundamentals'
     text: Plotly Fundamentals
 basic:
-    reference: '#basic-charts'
+    reference: 'basic-charts'
     text: Basic
 statistical:
-    reference: '#statistical-charts'
+    reference: 'statistical-charts'
     text: Statistical
 scientific:
-    reference: '#scientific-charts'
+    reference: 'scientific-charts'
     text: Scientific
 financial:
     reference: '#financial-charts'
     text: Financial
 maps:
-    reference: '#maps'
+    reference: 'maps'
     text: Maps
 3d_charts:
-    reference: '#3d-charts'
+    reference: '3d-charts'
     text: 3D
 multiple_axes:
-    reference: '#multiple-axes-subplots-and-insets'
+    reference: 'subplot-charts'
     text: Subplots
 transforms:
     reference: '#transforms'

--- a/_data/display_as.yml
+++ b/_data/display_as.yml
@@ -1,3 +1,15 @@
+mathematics:
+    reference: '#mathematics'
+    text: Mathematics
+statistics:
+    reference: '#statistics'
+    text: Statistics
+peak-analysis:
+    reference: '#peak-analysis'
+    text: Peak Analysis
+signal-analysis:
+    reference: '#signal-analysis'
+    text: Signal Analysis
 file_settings:
     reference: '#fundamentals'
     text: Plotly Fundamentals

--- a/_data/display_as.yml
+++ b/_data/display_as.yml
@@ -34,7 +34,7 @@ language:
 animations:
     reference: '#animations'
     text: Animations
-language:
+streaming:
     reference: '#streaming'
     text: Streaming
 databases:
@@ -151,6 +151,9 @@ text_documents:
 dashboards:
     reference: '#industry'
     text: By Industry
+chart_events:
+    reference: '#chart-events'
+    text: Chart Events
 ipython_notebooks_gallery:
     reference: '#language'
     text: By Data Science Language

--- a/_data/display_as.yml
+++ b/_data/display_as.yml
@@ -1,0 +1,156 @@
+file_settings:
+    reference: '#fundamentals'
+    text: Plotly Fundamentals
+basic:
+    reference: '#basic-charts'
+    text: Basic
+statistical:
+    reference: '#statistical-charts'
+    text: Statistical
+scientific:
+    reference: '#scientific-charts'
+    text: Scientific
+financial:
+    reference: '#financial-charts'
+    text: Financial
+maps:
+    reference: '#maps'
+    text: Maps
+3d_charts:
+    reference: '#3d-charts'
+    text: 3D
+multiple_axes:
+    reference: '#multiple-axes-subplots-and-insets'
+    text: Subplots
+transforms:
+    reference: '#transforms'
+    text: Transforms
+controls:
+    reference: '#controls'
+    text: Custom Controls
+language:
+    reference: '#chart-events'
+    text: Chart Events
+animations:
+    reference: '#animations'
+    text: Animations
+language:
+    reference: '#streaming'
+    text: Streaming
+databases:
+    reference: '#databases'
+    text: Connecting to Databases
+report_generation:
+    reference: '#report-generation'
+    text: Report Generation
+style_opt:
+    reference: '#style-options'
+    text: Style Options
+layout_opt:
+    reference: '#layout-options'
+    text: Layout Options
+legacy_charts:
+    reference: '#legacy-charts'
+    text: Legacy Charts
+tutorial:
+    reference: '#tutorial'
+    text: Tutorial
+get_request:
+    reference: '#static-image-export'
+    text: Image Export &amp; Retrieving Plots
+aesthetics:
+    reference: '#aes'
+    text: Aesthetics
+geoms:
+    reference: '#geoms'
+    text: Geoms
+faceting:
+    reference: '#faceting'
+    text: Faceting
+other:
+    reference: '#other'
+    text: Other
+theme:
+    reference: '#theme'
+    text: Theme
+general_examples:
+    reference: '#general-examples'
+    text: General Examples
+real_dataset:
+    reference: '#real_dataset'
+    text: Examples based on real world dataset
+biclustering:
+    reference: '#biclustering'
+    text: Biclustering
+calibration:
+    reference: '#calibration'
+    text: Calibration
+classification:
+    reference: '#classification'
+    text: Classification
+clustering:
+    reference: '#clustering'
+    text: Clustering
+covariance_estimation:
+    reference: '#covariance_estimation'
+    text: Covariance Estimation
+cross_decomposition:
+    reference: '#cross_decomposition '
+    text: Cross Decomposition
+dataset:
+    reference: '#dataset '
+    text: Dataset Examples
+decomposition:
+    reference: '#decomposition '
+    text: Decomposition
+ensemble_methods:
+    reference: '#ensemble_methods '
+    text: Ensemble Methods
+tutorial_exercises:
+    reference: '#tutorial_exercises '
+    text: Tutorial Exercises
+feature_selection:
+    reference: '#feature_selection '
+    text: Feature Selection
+gaussian-process:
+    reference: '#gaussian-process '
+    text: Gaussian Process for Machine Learning
+linear_models:
+    reference: '#linear_models '
+    text: Generalized Linear Models
+manifold_learning:
+    reference: '#manifold_learning '
+    text: Manifold Learning
+gaussian_mixture:
+    reference: '#gaussian_mixture'
+    text: Gaussian Mixture Models
+model_selection:
+    reference: '#model_selection'
+    text: Model Selection
+nearest_neighbors:
+    reference: '#nearest_neighbors '
+    text: Nearest Neighbors
+neural_networks:
+    reference: '#neural_networks '
+    text: Neural Networks
+preprocessing:
+    reference: '#preprocessing '
+    text: Preprocessing
+semi_supervised:
+    reference: '#semi_supervised '
+    text: Semi Supervised Classification
+vector_machines:
+    reference: '#vector_machines'
+    text: Support Vector Machines
+decision_trees:
+    reference: '#decision_trees'
+    text: Decision Trees
+text_documents:
+    reference: '#text_documents'
+    text: Working with Text Documents
+dashboards:
+    reference: '#industry'
+    text: By Industry
+ipython_notebooks_gallery:
+    reference: '#language'
+    text: By Data Science Language

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -34,8 +34,6 @@
             </li>
             {% endif %}
 
-            {% if page.layout != "langindex" %}
-            {% unless page.permalink == "/api/" %}
             
             {% if page.display_as != blank %}
             {% assign display_as = site.data.display_as[page.display_as] %}
@@ -51,11 +49,13 @@
             
             {% endif %}
 
+            {% if page.layout != "langindex" %}
+            {% unless page.permalink == "/api/" %}
+
             <li class="--breadcrumb-item">
                 <span>{{page.name}}</span>
             </li>
             {% endunless %}
-
             {% endif %}
         </ul>
 

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -36,6 +36,14 @@
 
             {% if page.layout != "langindex" %}
             {% unless page.permalink == "/api/" %}
+            
+            {% if page.display_as != blank %}
+	    
+            <li class="--breadcrumb-item">
+                <span>{{page.display_as}}</span>
+            </li>
+            
+            {% endif %}
 
             <li class="--breadcrumb-item">
                 <span>{{page.name}}</span>

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -44,7 +44,7 @@
 	        {% assign langue = 'javascript' %}
 	    {% endif %}
             <li class="--breadcrumb-item">
-		<a href="/{{ display_as.reference | prepend: langue }}">
+		<a href="/{{ display_as.reference | prepend: "/" | prepend: langue }}">
                 <span>{{ display_as.text }}</span>
 		</a>
             </li>

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -46,6 +46,7 @@
             <li class="--breadcrumb-item">
 		<a href="/{{ display_as.reference | prepend: langue }}">
                 <span>{{ display_as.text }}</span>
+		</a>
             </li>
             
             {% endif %}

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -38,9 +38,14 @@
             {% unless page.permalink == "/api/" %}
             
             {% if page.display_as != blank %}
-	    
+            {% assign display_as = site.data.display_as[page.display_as] %}
+	    {% assign langue = page.language %}
+	    {% if page.permalink contains 'javascript' %}
+	        {% assign langue = 'javascript' %}
+	    {% endif %}
             <li class="--breadcrumb-item">
-                <span>{{page.display_as}}</span>
+		<a href="/{{ display_as.reference | prepend: langue }}">
+                <span>{{ display_as.text }}</span>
             </li>
             
             {% endif %}


### PR DESCRIPTION
I changed added the text of display_as to appear in the breadcrumbs working towards [this issue](https://github.com/plotly/documentation/issues/855) but I was wondering if there is a way to set the text/link info for each category (basic, amimation, 3d ...) without having to paste in a couple hundred LOC similar to this https://github.com/plotly/documentation/blob/source-design-merge/_includes/side-bar.html#L288-L614.

@cldougl , @bcdunbar 