### PR TITLE
Legend click event

### DIFF
--- a/_posts/plotly_js/chart-events/events/2018-08-06-order6_legendclick_event.html
+++ b/_posts/plotly_js/chart-events/events/2018-08-06-order6_legendclick_event.html
@@ -9,7 +9,7 @@ arrangement: horizontal
 markdown_content: |
   `plotly_legendclick` and `plotly_legenddoubleclick` allow customization of the plotly legend. The default behaviour of `plotly_legendclick` is to hide a trace and the default behavior of `plotly_legenddoubleclick` is to select one trace and hide all the others. 
   We can add to the default behaviour by creating a new `plotly_legendclick` event with a function of our choice. We can also disable the default behaviour by creating a function that returns `false`. In the example below, we do both in order to create a `plotly_legendclick` event which changes the marker color back to black instead of erasing the trace.
---
+---
 
 var myPlot = document.getElementById('myDiv'),
     x = [1, 2, 3, 4, 5, 6],

--- a/_posts/plotly_js/chart-events/events/2018-08-06-order6_legendclick_event.html
+++ b/_posts/plotly_js/chart-events/events/2018-08-06-order6_legendclick_event.html
@@ -10,17 +10,16 @@ markdown_content: |
   `plotly_legendclick` and `plotly_legenddoubleclick` allow customization of the plotly legend. The default behaviour of `plotly_legendclick` is to hide a trace and the default behavior of `plotly_legenddoubleclick` is to select one trace and hide all the others. 
   We can add to the default behaviour by creating a new `plotly_legendclick` event with a function of our choice. We can also disable the default behaviour by creating a function that returns `false`. In the example below, we do both in order to create a `plotly_legendclick` event which changes the marker color back to black instead of erasing the trace.
 ---
-
 var myPlot = document.getElementById('myDiv'),
     x = [1, 2, 3, 4, 5, 6],
     y = [1, 2, 3, 2, 3, 4],
     y2 = [1, 4, 7, 6, 1, 5],
-    colors = [['#00000','#00000','#00000','#00000','#00000','#00000'],
-              ['#00000','#00000','#00000','#00000','#00000','#00000']],
+    colors = [['#5C636E','#5C636E','#5C636E','#5C636E','#5C636E','#5C636E'],
+              ['#393e46','#393e46','#393e46','#393e46','#393e46','#393e46']],
     data = [{x:x, y:y, type:'scatter',
-             mode:'line', line:{ color:'red'},marker:{size:16, color:colors[0]}},
+             mode:'line', line:{ color:'#5C636E'},marker:{size:16, color:colors[0]}},
             {x:x, y:y2, type:'scatter',
-             mode:'line',line:{ color:'black'}, marker:{size:16, color:colors[1]}}],
+             mode:'line',line:{ color:'#393e46'}, marker:{size:16, color:colors[1]}}],
     layout = {
         showlegend: true,
         hovermode:'closest',
@@ -44,9 +43,9 @@ myPlot.on('plotly_click', function(data){
 });
 
 myPlot.on('plotly_legendclick', function(data){
-  var trColors = ['#00000','#00000','#00000',
-                   '#00000','#00000','#00000'];
-  var update = {'marker':{color: trColors, size:16}};
+  var trColors = [['#5C636E','#5C636E','#5C636E','#5C636E','#5C636E','#5C636E'],
+              ['#393e46','#393e46','#393e46','#393e46','#393e46','#393e46']];
+  var update = {'marker':{color: trColors[data.curveNumber], size:16}};
   Plotly.restyle('myDiv', update,[data.curveNumber]);
   return false;
 });

--- a/_posts/plotly_js/chart-events/events/2018-08-06-order6_legendclick_event.html
+++ b/_posts/plotly_js/chart-events/events/2018-08-06-order6_legendclick_event.html
@@ -1,0 +1,52 @@
+---
+name: Legend Click Events
+plot_url: https://codepen.io/plotly/embed/vazxKv/?height=500&theme-id=15263&default-tab=result
+language: plotly_js
+suite: events
+order: 4.1
+sitemap: false
+arrangement: horizontal
+markdown_content: |
+  `plotly_legendclick` and `plotly_legenddoubleclick` allow customization of the plotly legend. The default behaviour of `plotly_legendclick` is to hide a trace and the default behavior of `plotly_legenddoubleclick` is to select one trace and hide all the others. 
+  We can add to the default behaviour by creating a new `plotly_legendclick` event with a function of our choice. We can also disable the default behaviour by creating a function that returns `false`. In the example below, we do both in order to create a `plotly_legendclick` event which changes the marker color back to black instead of erasing the trace.
+--
+
+var myPlot = document.getElementById('myDiv'),
+    x = [1, 2, 3, 4, 5, 6],
+    y = [1, 2, 3, 2, 3, 4],
+    y2 = [1, 4, 7, 6, 1, 5],
+    colors = [['#00000','#00000','#00000','#00000','#00000','#00000'],
+              ['#00000','#00000','#00000','#00000','#00000','#00000']],
+    data = [{x:x, y:y, type:'scatter',
+             mode:'line', line:{ color:'red'},marker:{size:16, color:colors[0]}},
+            {x:x, y:y2, type:'scatter',
+             mode:'line',line:{ color:'black'}, marker:{size:16, color:colors[1]}}],
+    layout = {
+        showlegend: true,
+        hovermode:'closest',
+        title:'Click on a Point to Change Color<br>Click on a Trace in the Legend to Change Back One Trace Only'
+     };
+
+Plotly.newPlot('myDiv', data, layout);
+
+myPlot.on('plotly_click', function(data){
+  var pn='',
+      tn='',
+      colors=[];
+  for(var i=0; i < data.points.length; i++){
+    pn = data.points[i].pointNumber;
+    tn = data.points[i].curveNumber;
+    colors = data.points[i].data.marker.color;
+  };
+  colors[pn] = '#C54C82';
+  var update = {'marker':{color: colors, size:16}};
+  Plotly.restyle('myDiv', update,[tn]);
+});
+
+myPlot.on('plotly_legendclick', function(data){
+  var trColors = ['#00000','#00000','#00000',
+                   '#00000','#00000','#00000'];
+  var update = {'marker':{color: trColors, size:16}};
+  Plotly.restyle('myDiv', update,[data.curveNumber]);
+  return false;
+});


### PR DESCRIPTION
I updated plot.ly/javascript/plotlyjs_events with a new section on legend click events to deal with [this issue](https://github.com/plotly/documentation/issues/937). 

Unfortunately, the only way I can access this page is through the link or by searching at the moment.
@cldougl  , Is this what we want or would it be better for a link to this page to appear here:

![javascript chart events](https://user-images.githubusercontent.com/41019918/43742521-45d9fdd2-99a0-11e8-811d-66dbce494e27.png)
