### PR TITLE
remove *Examples* from sidebar bar "more _ examples pages"

### DIFF
--- a/_includes/side-bar.html
+++ b/_includes/side-bar.html
@@ -28,6 +28,8 @@
 {% assign language = "scikit-learn" %}
 {% endif %}
 
+{% assign display_as = page.display_as %}
+
 {% assign pages_list = site.posts | where:"language", language %}
 
 {% for page in pages_list %}
@@ -139,6 +141,7 @@
 {% elsif page.display_as == "decision_trees" %}
 {% assign decision_trees = true %}
 <!-- END OF SCIKIT CUSTOM LAYOUT -->
+
 {% endif %}
 {% endfor %}
 
@@ -282,6 +285,7 @@
         </nav>
 
         <!-- Examples start -->
+	{% unless display_as %}
         <header class="--sidebar-header">Examples</header>
         <nav class="--sidebar-body watch" id="where">
             <ul class="--sidebar-list">
@@ -404,6 +408,7 @@
                     <a href="#static-image-export" class="js-splash--navigation-item">Image Export &amp; Retrieving Plots</a>
                 </li>
                 {% endif %}
+
 
                 <!-- START OF GGPLOT CUSTOM LAYOUT -->
                 {% if aesthetics == true %}
@@ -614,6 +619,7 @@
                 {% endif %}
             </ul>
         </nav>
+	{% endunless %}
         <!-- Community -->
         <header class="--sidebar-header">Community</header>
         <nav class="--sidebar-body watch" id="where">


### PR DESCRIPTION
this pr fixes [854](https://github.com/plotly/documentation/issues/854) by skipping adding the examples on the side-bar for any page that isn't the true langindex.