### PR TITLE
Change GitHub Repo URL in Contributing.md

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -5,7 +5,7 @@ Edit or add files in the `_posts` folder in the [source-design-merge](http://git
 1. Clone the repo and then check out the source-design-merge branch:
 
   ```
-  $ git clone git@github.com:plotly/documentation.git
+  $ git clone https://github.com/plotly/documentation.git
   $ git fetch origin
   $ git checkout source-design-merge
   ```


### PR DESCRIPTION
When following these instructions, I get the following error on my local machine:

Cloning into 'documentation'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

I recommend changing the URL to https://github.com/plotly/documentation.git, as this resolved the error. 