### PR TITLE
fixing warning

### DIFF
--- a/_posts/python/statistical/box/box.ipynb
+++ b/_posts/python/statistical/box/box.ipynb
@@ -574,7 +574,7 @@
     "\n",
     "from numpy import * \n",
     "\n",
-    "N = 30.     # Number of boxes\n",
+    "N = 30     # Number of boxes\n",
     "\n",
     "# generate an array of rainbow colors by fixing the saturation and lightness of the HSL representation of colour \n",
     "# and marching around the hue. \n",


### PR DESCRIPTION
DeprecationWarning:
object of type <class 'float'> cannot be safely interpreted as an integer.