### PR TITLE
remove legacy from sidebar

### DIFF
--- a/_includes/side-bar.html
+++ b/_includes/side-bar.html
@@ -65,8 +65,6 @@
 {% assign style_opt = true %}
 {% elsif page.display_as == "layout_opt" %}
 {% assign layout_opt = true %}
-{% elsif page.display_as == "legacy_charts" %}
-{% assign legacy_charts = true %}
 {% elsif page.display_as == "tutorial" %}
 {% assign tutorial = true %}
 {% elsif page.display_as == "get_request" %}
@@ -391,12 +389,6 @@
                 </li>
                 {% endif %}
 
-                {% if legacy_charts == true %}
-                <li class="--sidebar-item">
-                    <a href="#legacy-charts" class="js-splash--navigation-item">Legacy Charts</a>
-                </li>
-                {% endif %}
-                
                 {% if tutorial == true %}
                 <li class="--sidebar-item">
                     <a href="#tutorial" class="js-splash--navigation-item">Tutorial</a>


### PR DESCRIPTION
resolves https://github.com/plotly/documentation/issues/957

- removes legacy-charts from `side-bar.html`