### PR TITLE
fix syntax error in first plot and add font settings section to dashboard api

### DIFF
--- a/_posts/python/legacy/dashboard/2015-06-30-dashboard-api.html
+++ b/_posts/python/legacy/dashboard/2015-06-30-dashboard-api.html
@@ -8,9 +8,9 @@ layout: user-guide
 name: Dashboard API
 language: python
 title: Dashboard API | plotly
-display_as: legacy_charts
+display_as: file_settings
 has_thumbnail: true
-page_type: u-guide
+page_type: example_index
 order: 0
 ipynb: ~notebook_demo/148
 ---
@@ -53,7 +53,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>&#39;2.5.1&#39;</pre>
+<pre>&#39;3.3.0&#39;</pre>
 </div>
 
 </div>
@@ -78,7 +78,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[50]:</div>
+<div class="prompt input_prompt">In&nbsp;[3]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">plotly.dashboard_objs</span> <span class="kn">as</span> <span class="nn">dashboard</span>
@@ -119,7 +119,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
     <span class="n">y</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="mi">500</span><span class="p">),</span>
     <span class="n">mode</span><span class="o">=</span><span class="s1">&#39;markers&#39;</span><span class="p">,</span>
     <span class="n">marker</span><span class="o">=</span><span class="nb">dict</span><span class="p">(</span>
-        <span class="n">size</span><span class="o">=</span><span class="s1">&#39;16&#39;</span><span class="p">,</span>
+        <span class="n">size</span><span class="o">=</span><span class="mi">16</span><span class="p">,</span>
         <span class="n">color</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="mi">500</span><span class="p">),</span>
         <span class="n">colorscale</span><span class="o">=</span><span class="n">colorscale</span><span class="p">,</span>
         <span class="n">showscale</span><span class="o">=</span><span class="bp">True</span>
@@ -145,7 +145,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 
 <div class="output_html rendered_html output_subarea output_execute_result">
-<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~PlotBot/1296.embed" height="525px" width="100%"></iframe>
+<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~PythonPlotBot/536.embed" height="525px" width="100%"></iframe>
 </div>
 
 </div>
@@ -205,7 +205,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 
 <div class="output_html rendered_html output_subarea output_execute_result">
-<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~PlotBot/1342.embed" height="525px" width="100%"></iframe>
+<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" src="https://plot.ly/~PythonPlotBot/1921.embed" height="525px" width="100%"></iframe>
 </div>
 
 </div>
@@ -238,7 +238,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>u&#39;https://plot.ly/~PlotBot/1342?share_key=uVoeGB1i8Xf4fk0b57sT2l&#39;</pre>
+<pre>u&#39;https://plot.ly/~PythonPlotBot/1921?share_key=w7FG9pTIho04mm8RQrByAr&#39;</pre>
 </div>
 
 </div>
@@ -306,7 +306,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[51]:</div>
+<div class="prompt input_prompt">In&nbsp;[7]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">re</span>
@@ -381,7 +381,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[52]:</div>
+<div class="prompt input_prompt">In&nbsp;[8]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="o">.</span><span class="n">get_preview</span><span class="p">()</span>
@@ -397,7 +397,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[52]:</div>
+<div class="prompt output_prompt">Out[8]:</div>
 
 
 
@@ -442,7 +442,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[53]:</div>
+<div class="prompt input_prompt">In&nbsp;[9]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">box_a</span><span class="p">,</span> <span class="s1">&#39;above&#39;</span><span class="p">,</span> <span class="mi">1</span><span class="p">)</span>
@@ -473,7 +473,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[54]:</div>
+<div class="prompt input_prompt">In&nbsp;[10]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">box_b</span><span class="p">,</span> <span class="s1">&#39;left&#39;</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="n">fill_percent</span><span class="o">=</span><span class="mi">30</span><span class="p">)</span>
@@ -505,7 +505,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[55]:</div>
+<div class="prompt input_prompt">In&nbsp;[11]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="o">.</span><span class="n">get_box</span><span class="p">(</span><span class="mi">1</span><span class="p">)</span>
@@ -521,7 +521,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[55]:</div>
+<div class="prompt output_prompt">Out[11]:</div>
 
 
 
@@ -550,7 +550,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[56]:</div>
+<div class="prompt input_prompt">In&nbsp;[12]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="o">.</span><span class="n">get_box</span><span class="p">(</span><span class="mi">1</span><span class="p">)[</span><span class="s1">&#39;title&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;a new title&#39;</span>
@@ -567,7 +567,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[56]:</div>
+<div class="prompt output_prompt">Out[12]:</div>
 
 
 
@@ -596,7 +596,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[57]:</div>
+<div class="prompt input_prompt">In&nbsp;[13]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="o">.</span><span class="n">get_box</span><span class="p">(</span><span class="mi">3</span><span class="p">)[</span><span class="s1">&#39;title&#39;</span><span class="p">]</span>
@@ -612,7 +612,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[57]:</div>
+<div class="prompt output_prompt">Out[13]:</div>
 
 
 
@@ -629,7 +629,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[58]:</div>
+<div class="prompt input_prompt">In&nbsp;[14]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="o">.</span><span class="n">swap</span><span class="p">(</span><span class="mi">2</span><span class="p">,</span> <span class="mi">3</span><span class="p">)</span>
@@ -646,7 +646,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[58]:</div>
+<div class="prompt output_prompt">Out[14]:</div>
 
 
 
@@ -672,7 +672,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[59]:</div>
+<div class="prompt input_prompt">In&nbsp;[15]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">box_a</span><span class="p">,</span> <span class="s1">&#39;below&#39;</span><span class="p">,</span> <span class="mi">2</span><span class="p">)</span>
@@ -694,7 +694,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[60]:</div>
+<div class="prompt input_prompt">In&nbsp;[16]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="o">.</span><span class="n">remove</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
@@ -725,7 +725,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[61]:</div>
+<div class="prompt input_prompt">In&nbsp;[17]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;title&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;My First Dashboard with Python&#39;</span>
@@ -747,7 +747,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[62]:</div>
+<div class="prompt input_prompt">In&nbsp;[18]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;logoUrl&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;https://images.plot.ly/language-icons/api-home/python-logo.png&#39;</span>
@@ -769,7 +769,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[63]:</div>
+<div class="prompt input_prompt">In&nbsp;[19]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;links&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[]</span>
@@ -792,7 +792,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[64]:</div>
+<div class="prompt input_prompt">In&nbsp;[20]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;foregroundColor&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;#000000&#39;</span>
@@ -813,13 +813,37 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
+<h4 id="Change-Font-Settings">Change Font Settings<a class="anchor-link" href="#Change-Font-Settings">&#194;&#182;</a></h4><p>Note that all other settings available in the <a href="https://plot.ly/dashboard/create/#/">dashboard online creator</a> are also available to with the dashboard API.</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[21]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;fontFamily&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;Raleway&#39;</span>
+<span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;headerFontSize&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;1.6em&#39;</span>
+<span class="n">my_dboard</span><span class="p">[</span><span class="s1">&#39;settings&#39;</span><span class="p">][</span><span class="s1">&#39;headerFontWeight&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;200&#39;</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
 <h4 id="Update-Dashboard-Size">Update Dashboard Size<a class="anchor-link" href="#Update-Dashboard-Size">&#194;&#182;</a></h4>
 </div>
 </div>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[65]:</div>
+<div class="prompt input_prompt">In&nbsp;[22]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">stacked_dboard</span> <span class="o">=</span> <span class="n">dashboard</span><span class="o">.</span><span class="n">Dashboard</span><span class="p">()</span>
@@ -849,7 +873,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[66]:</div>
+<div class="prompt input_prompt">In&nbsp;[23]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">stacked_dboard</span><span class="p">[</span><span class="s1">&#39;layout&#39;</span><span class="p">][</span><span class="s1">&#39;size&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="mi">3000</span>
@@ -871,7 +895,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[67]:</div>
+<div class="prompt input_prompt">In&nbsp;[24]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">plotly.plotly</span> <span class="kn">as</span> <span class="nn">py</span>
@@ -888,13 +912,13 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[67]:</div>
+<div class="prompt output_prompt">Out[24]:</div>
 
 
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>u&#39;https://plot.ly/~PlotBot/1327/my-first-dashboard-with-python/&#39;</pre>
+<pre>u&#39;https://plot.ly/~PythonPlotBot/540/my-first-dashboard-with-python/&#39;</pre>
 </div>
 
 </div>
@@ -923,7 +947,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[70]:</div>
+<div class="prompt input_prompt">In&nbsp;[25]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">py</span><span class="o">.</span><span class="n">dashboard_ops</span><span class="o">.</span><span class="n">get_dashboard_names</span><span class="p">()</span>
@@ -939,13 +963,13 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[70]:</div>
+<div class="prompt output_prompt">Out[25]:</div>
 
 
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>[&#39;My First Dashboard with Python&#39;]</pre>
+<pre>[&#39;My First Dashboard with Python&#39;, &#39;DashboardDemo&#39;]</pre>
 </div>
 
 </div>
@@ -956,7 +980,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[71]:</div>
+<div class="prompt input_prompt">In&nbsp;[26]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">recent_dboard</span> <span class="o">=</span> <span class="n">py</span><span class="o">.</span><span class="n">dashboard_ops</span><span class="o">.</span><span class="n">get_dashboard</span><span class="p">(</span><span class="s1">&#39;My First Dashboard with Python&#39;</span><span class="p">)</span>
@@ -992,7 +1016,7 @@ Run  <code>pip install plotly --upgrade</code> to update your Plotly version.</p
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[72]:</div>
+<div class="prompt input_prompt">In&nbsp;[27]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span></span><span class="n">help</span><span class="p">(</span><span class="n">py</span><span class="o">.</span><span class="n">dashboard_ops</span><span class="p">)</span>

--- a/_posts/python/legacy/dashboard/2015-06-30-dashboard-api.html
+++ b/_posts/python/legacy/dashboard/2015-06-30-dashboard-api.html
@@ -8,9 +8,9 @@ layout: user-guide
 name: Dashboard API
 language: python
 title: Dashboard API | plotly
-display_as: file_settings
+display_as: legacy_charts
 has_thumbnail: true
-page_type: example_index
+page_type: u-guide
 order: 0
 ipynb: ~notebook_demo/148
 ---

--- a/_posts/python/legacy/dashboard/dashboard-api.ipynb
+++ b/_posts/python/legacy/dashboard/dashboard-api.ipynb
@@ -21,7 +21,7 @@
     {
      "data": {
       "text/plain": [
-       "'2.5.1'"
+       "'3.3.0'"
       ]
      },
      "execution_count": 1,
@@ -54,10 +54,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import plotly.dashboard_objs as dashboard\n",
@@ -79,19 +77,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~chelsea_lyn/15005.embed\" height=\"525px\" width=\"100%\"></iframe>"
+       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~PythonPlotBot/536.embed\" height=\"525px\" width=\"100%\"></iframe>"
       ],
       "text/plain": [
        "<plotly.tools.PlotlyDisplay object>"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -133,7 +131,7 @@
     {
      "data": {
       "text/html": [
-       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~PlotBot/1342.embed\" height=\"525px\" width=\"100%\"></iframe>"
+       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~PythonPlotBot/1921.embed\" height=\"525px\" width=\"100%\"></iframe>"
       ],
       "text/plain": [
        "<plotly.tools.PlotlyDisplay object>"
@@ -175,7 +173,7 @@
     {
      "data": {
       "text/plain": [
-       "u'https://plot.ly/~PlotBot/1342?share_key=uVoeGB1i8Xf4fk0b57sT2l'"
+       "u'https://plot.ly/~PythonPlotBot/1921?share_key=w7FG9pTIho04mm8RQrByAr'"
       ]
      },
      "execution_count": 6,
@@ -244,10 +242,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import re\n",
@@ -315,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -355,7 +351,7 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -366,10 +362,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [],
    "source": [
     "my_dboard.insert(box_a, 'above', 1)"
@@ -394,10 +388,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 10,
+   "metadata": {},
    "outputs": [],
    "source": [
     "my_dboard.insert(box_b, 'left', 1, fill_percent=30)"
@@ -422,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -434,7 +426,7 @@
        " 'type': 'box'}"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -452,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -464,7 +456,7 @@
        " 'type': 'box'}"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -484,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -493,7 +485,7 @@
        "'box-for-dashboard'"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -504,7 +496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -513,7 +505,7 @@
        "'scatter-for-dashboard'"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -533,10 +525,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 15,
+   "metadata": {},
    "outputs": [],
    "source": [
     "my_dboard.insert(box_a, 'below', 2)"
@@ -551,10 +541,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 16,
+   "metadata": {},
    "outputs": [],
    "source": [
     "my_dboard.remove(3)"
@@ -577,10 +565,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 17,
+   "metadata": {},
    "outputs": [],
    "source": [
     "my_dboard['settings']['title'] = 'My First Dashboard with Python'"
@@ -596,10 +582,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 18,
+   "metadata": {},
    "outputs": [],
    "source": [
     "my_dboard['settings']['logoUrl'] = 'https://images.plot.ly/language-icons/api-home/python-logo.png'"
@@ -615,10 +599,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 19,
+   "metadata": {},
    "outputs": [],
    "source": [
     "my_dboard['settings']['links'] = []\n",
@@ -635,10 +617,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 20,
+   "metadata": {},
    "outputs": [],
    "source": [
     "my_dboard['settings']['foregroundColor'] = '#000000'\n",
@@ -654,14 +634,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Change Font Settings\n",
+    "\n",
+    "Note that all other settings available in the [dashboard online creator](https://plot.ly/dashboard/create/#/) are also available to with the dashboard API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_dboard['settings']['fontFamily'] = 'Raleway'\n",
+    "my_dboard['settings']['headerFontSize'] = '1.6em'\n",
+    "my_dboard['settings']['headerFontWeight'] = '200'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Update Dashboard Size"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 22,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -686,10 +685,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 23,
+   "metadata": {},
    "outputs": [],
    "source": [
     "stacked_dboard['layout']['size'] = 3000"
@@ -705,16 +702,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "u'https://plot.ly/~PlotBot/1327/my-first-dashboard-with-python/'"
+       "u'https://plot.ly/~PythonPlotBot/540/my-first-dashboard-with-python/'"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -741,16 +738,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['My First Dashboard with Python']"
+       "['My First Dashboard with Python', 'DashboardDemo']"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -761,10 +758,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 26,
+   "metadata": {},
    "outputs": [],
    "source": [
     "recent_dboard = py.dashboard_ops.get_dashboard('My First Dashboard with Python')"
@@ -792,7 +787,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -882,7 +877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -914,26 +909,27 @@
      "output_type": "stream",
      "text": [
       "Collecting git+https://github.com/plotly/publisher.git\n",
-      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/k_/zf24qrfn2kg710j9pdrxzrz40000gn/T/pip-qkN2l0-build\n",
+      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-req-build-HMjVGC\n",
+      "Building wheels for collected packages: publisher\n",
+      "  Running setup.py bdist_wheel for publisher ... \u001b[?25ldone\n",
+      "\u001b[?25h  Stored in directory: /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-ephem-wheel-cache-fXvw18/wheels/99/3e/a0/fbd22ba24cca72bdbaba53dbc23c1768755fb17b3af0f33966\n",
+      "Successfully built publisher\n",
       "Installing collected packages: publisher\n",
       "  Found existing installation: publisher 0.11\n",
       "    Uninstalling publisher-0.11:\n",
       "      Successfully uninstalled publisher-0.11\n",
-      "  Running setup.py install for publisher ... \u001b[?25ldone\n",
-      "\u001b[?25hSuccessfully installed publisher-0.11\n",
-      "\u001b[33mYou are using pip version 9.0.3, however version 10.0.1 is available.\n",
-      "You should consider upgrading via the 'pip install --upgrade pip' command.\u001b[0m\n"
+      "Successfully installed publisher-0.11\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/chelsea/venv/venv2/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning:\n",
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning:\n",
       "\n",
       "The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
       "\n",
-      "/Users/chelsea/venv/venv2/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning:\n",
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning:\n",
       "\n",
       "Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
       "\n"
@@ -985,7 +981,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/_posts/python/legacy/dashboard/dashboard-api.ipynb
+++ b/_posts/python/legacy/dashboard/dashboard-api.ipynb
@@ -877,7 +877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -909,10 +909,10 @@
      "output_type": "stream",
      "text": [
       "Collecting git+https://github.com/plotly/publisher.git\n",
-      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-req-build-HMjVGC\n",
+      "  Cloning https://github.com/plotly/publisher.git to /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-req-build-afQWHg\n",
       "Building wheels for collected packages: publisher\n",
       "  Running setup.py bdist_wheel for publisher ... \u001b[?25ldone\n",
-      "\u001b[?25h  Stored in directory: /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-ephem-wheel-cache-fXvw18/wheels/99/3e/a0/fbd22ba24cca72bdbaba53dbc23c1768755fb17b3af0f33966\n",
+      "\u001b[?25h  Stored in directory: /private/var/folders/tc/bs9g6vrd36q74m5t8h9cgphh0000gn/T/pip-ephem-wheel-cache-BuRmpR/wheels/99/3e/a0/fbd22ba24cca72bdbaba53dbc23c1768755fb17b3af0f33966\n",
       "Successfully built publisher\n",
       "Installing collected packages: publisher\n",
       "  Found existing installation: publisher 0.11\n",
@@ -925,14 +925,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning:\n",
-      "\n",
-      "The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
-      "\n",
-      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning:\n",
-      "\n",
-      "Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
-      "\n"
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning: The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.\n",
+      "  \"You should import from nbconvert instead.\", ShimWarning)\n",
+      "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/publisher/publisher.py:53: UserWarning: Did you \"Save\" this notebook before running this command? Remember to save, always save.\n",
+      "  warnings.warn('Did you \"Save\" this notebook before running this command? '\n"
      ]
     }
    ],
@@ -950,7 +946,7 @@
     "    title = 'Dashboard API | plotly',\n",
     "    name = 'Dashboard API',\n",
     "    thumbnail='thumbnail/dashboard.jpg', language='python',\n",
-    "    page_type='example_index', has_thumbnail='true', display_as='file_settings',\n",
+    "    page_type='u-guide', has_thumbnail='true', display_as='legacy_charts',\n",
     "    ipynb= '~notebook_demo/148', order=0)"
    ]
   },


### PR DESCRIPTION
in response to: https://github.com/plotly/plotly.py/issues/1225#event-1906442020

- updates the html file for dashboards api legacy doc ('16' -> integer)
- adds a section about updating the font with some examples

I did not:
- update the png image of the dashboard in the doc found here: https://plot.ly/python/create-online-dashboard/#upload-dashboard

The new dashboard with the modified font looks like: https://plot.ly/dashboard/PythonPlotBot:540/view#/

Don't think it is worth to update, especially since this is legacy and since we want to encourage users to check out Dash anyways. But I felt this update is useful for users like the one above who don't know that fonts are capable of being specified through the api.