### PR TITLE
add DOM to makeTemplate call sig in js function reference.

### DIFF
--- a/_posts/reference_pages/2016-06-03-plotly_js_function_ref.html
+++ b/_posts/reference_pages/2016-06-03-plotly_js_function_ref.html
@@ -371,8 +371,9 @@ console.log(out[0].msg)
   <dt><code>Plotly.makeTemplate(figure)</code></dt>
   <dd>
     <dl>
-      <dt><code>figure</code></dt>
-      <dd>a plot object, with <code>{data, layout}</code> members
+      <dt><code>figure</code> or <code>DOM Node</code></dt>
+      <dd>where <code>figure</code> is a plot object, with <code>{data, layout}</code> members. If a DOM node is used
+      it must be a div element already containing a plot.
     </dl>
   </dd>
 </dl>


### PR DESCRIPTION
resolves #1138 . To be merged when Plotly.js 1.42 is released