### PR TITLE
Download links for matplotlib and ipython

### DIFF
--- a/_posts/matplotlib/2015-04-05-matplotlib-index.html
+++ b/_posts/matplotlib/2015-04-05-matplotlib-index.html
@@ -1,16 +1,10 @@
 ---
 title: Matplotlib Figures Online | Plotly
 permalink: /matplotlib/
-description: Publish your Matplotlib figures to the web with one line of code! Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.
+description: Publish your Matplotlib figures to the web with one line of code! Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.<br><br>Instructions on how to install matplotlib can be found at <a class="no_underline plot-blue" href="https://matplotlib.org/users/installing.html">https://matplotlib.org/users/installing.html</a>.
 layout: langindex
 language: matplotlib
 ---
-
-
-<p>
-    Instructions on how to install matplotlib can be found at <a class="no_underline plot-blue" href="https://matplotlib.org/users/installing.html">https://matplotlib.org/users/installing.html</a>.
-</p>
-
 
 <header class="--welcome">
 	<div class="--welcome-body">

--- a/_posts/matplotlib/2015-04-05-matplotlib-index.html
+++ b/_posts/matplotlib/2015-04-05-matplotlib-index.html
@@ -6,6 +6,12 @@ layout: langindex
 language: matplotlib
 ---
 
+
+<p>
+    Instructions on how to install matplotlib can be found at <a class="no_underline plot-blue" href="https://matplotlib.org/users/installing.html">https://matplotlib.org/users/installing.html</a>.
+</p>
+
+
 <header class="--welcome">
 	<div class="--welcome-body">
 		<!--div.--wrap-inner-->


### PR DESCRIPTION
RE THIS ISSUE: https://github.com/plotly/documentation/issues/342

It looks like the Ipython page [here](https://plot.ly/ipython-notebooks/) already has a link, so I only needed to add one to matplotlib.

@cldougl ready for a review
