### PR TITLE
Meta links fixed in matplotlib index page 

### DIFF
--- a/_posts/matplotlib/2015-04-05-matplotlib-index.html
+++ b/_posts/matplotlib/2015-04-05-matplotlib-index.html
@@ -1,7 +1,7 @@
 ---
 title: Matplotlib Figures Online | Plotly
 permalink: /matplotlib/
-description: Publish your Matplotlib figures to the web with one line of code! Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.<br><br>Instructions on how to install matplotlib can be found at <a class='no_underline plot-blue" href="https://matplotlib.org/users/installing.html'>https://matplotlib.org/users/installing.html</a>.
+description: Publish your Matplotlib figures to the web with one line of code! Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.<br><br>Instructions on how to install matplotlib can be found at <a class='no_underline plot-blue' href='https://matplotlib.org/users/installing.html'>https://matplotlib.org/users/installing.html</a>.
 layout: langindex
 language: matplotlib
 ---

--- a/_posts/matplotlib/2015-04-05-matplotlib-index.html
+++ b/_posts/matplotlib/2015-04-05-matplotlib-index.html
@@ -1,7 +1,7 @@
 ---
 title: Matplotlib Figures Online | Plotly
 permalink: /matplotlib/
-description: Publish your Matplotlib figures to the web with one line of code! Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.<br><br>Instructions on how to install matplotlib can be found at <a class="no_underline plot-blue" href="https://matplotlib.org/users/installing.html">https://matplotlib.org/users/installing.html</a>.
+description: Publish your Matplotlib figures to the web with one line of code! Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.<br><br>Instructions on how to install matplotlib can be found at <a class='no_underline plot-blue" href="https://matplotlib.org/users/installing.html'>https://matplotlib.org/users/installing.html</a>.
 layout: langindex
 language: matplotlib
 ---

--- a/_posts/matplotlib/2015-04-05-matplotlib-index.html
+++ b/_posts/matplotlib/2015-04-05-matplotlib-index.html
@@ -1,7 +1,7 @@
 ---
 title: Matplotlib Figures Online | Plotly
 permalink: /matplotlib/
-description: Publish your Matplotlib figures to the web with one line of code! Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.<br><br>Instructions on how to install matplotlib can be found at <a class='no_underline plot-blue' href='https://matplotlib.org/users/installing.html '>https://matplotlib.org/users/installing.html </a>.
+description: Publish your Matplotlib figures to the web with one line of code! Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.<br><br>Instructions on how to install matplotlib can be found at <a class='no_underline plot-blue' href='https://matplotlib.org/users/installing.html'>https://matplotlib.org/users/installing.html</a>.
 layout: langindex
 language: matplotlib
 ---

--- a/_posts/matplotlib/2015-04-05-matplotlib-index.html
+++ b/_posts/matplotlib/2015-04-05-matplotlib-index.html
@@ -1,7 +1,7 @@
 ---
 title: Matplotlib Figures Online | Plotly
 permalink: /matplotlib/
-description: Publish your Matplotlib figures to the web with one line of code! Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.<br><br>Instructions on how to install matplotlib can be found at <a class='no_underline plot-blue' href='https://matplotlib.org/users/installing.html'>https://matplotlib.org/users/installing.html</a>.
+description: Publish your Matplotlib figures to the web with one line of code! Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.<br><br>Instructions on how to install matplotlib can be found at <a class='no_underline plot-blue' href='https://matplotlib.org/users/installing.html '>https://matplotlib.org/users/installing.html </a>.
 layout: langindex
 language: matplotlib
 ---


### PR DESCRIPTION
fixes https://github.com/plotly/documentation/issues/1177

inspecting the page and looking at the meta tag looks good to me - both links are clickable now

![screen shot 2018-11-19 at 2 42 43 pm](https://user-images.githubusercontent.com/10369095/48731175-71ed3800-ec0a-11e8-8910-c918523397c9.png)

ready for review cc. @cldougl 