### PR TITLE
explicitly set width of iframe for advanced violin example to fix layout

### DIFF
--- a/_posts/plotly_js/statistical/violin/2018-01-16-advanced-violin.html
+++ b/_posts/plotly_js/statistical/violin/2018-01-16-advanced-violin.html
@@ -6,6 +6,7 @@ suite: violin
 order: 6
 sitemap: false
 arrangement: horizontal
+width: 700
 ---
 
 var trace1 = {


### PR DESCRIPTION
fix #1209 by explicitly setting the width of the codepen's iframe to 700 pixels