### PR TITLE
change title of main page

### DIFF
--- a/_posts/2015-07-26-index.html
+++ b/_posts/2015-07-26-index.html
@@ -1,5 +1,5 @@
 ---
-title: Plotly API
+title: Plotly Open Source Graphing Libraries
 permalink: /api/
 ---
 


### PR DESCRIPTION
This page shouldn't be titled "Plotly API" any more :)

![image](https://user-images.githubusercontent.com/203523/51081157-29f10b80-16b7-11e9-9a20-2d585183dbe2.png)
