### PR TITLE
Fixing geom_sf Typo

### DIFF
--- a/_posts/ggplot2/2018-06-22-geom_sf.Rmd
+++ b/_posts/ggplot2/2018-06-22-geom_sf.Rmd
@@ -1,5 +1,5 @@
 ---
-title: grom_sf in ggplot2 | Examples | Plotly
+title: geom_sf in ggplot2 | Examples | Plotly
 name: geom_sf
 permalink: ggplot2/maps-sf/
 description: How to use geom_sf with Plotly.

--- a/_posts/ggplot2/2018-06-22-geom_sf.md
+++ b/_posts/ggplot2/2018-06-22-geom_sf.md
@@ -1,5 +1,5 @@
 ---
-title: grom_sf in ggplot2 | Examples | Plotly
+title: geom_sf in ggplot2 | Examples | Plotly
 name: geom_sf
 permalink: ggplot2/maps-sf/
 description: How to use geom_sf with Plotly.


### PR DESCRIPTION
This appeared on the google search results page. I thought it might lead to some confusion and it was easy to edit. 