### PR TITLE
Fixed typo preventing execution of example code

### DIFF
--- a/_posts/python/user_guide_python/new_py_guide.ipynb
+++ b/_posts/python/user_guide_python/new_py_guide.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -33,13 +33,13 @@
     {
      "data": {
       "text/html": [
-       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~kevintest/356.embed\" height=\"525px\" width=\"100%\"></iframe>"
+       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~bradprin/22.embed\" height=\"525px\" width=\"100%\"></iframe>"
       ],
       "text/plain": [
        "<plotly.tools.PlotlyDisplay object>"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -48,7 +48,7 @@
     "import plotly.plotly as py\n",
     "import plotly.graph_objs as go\n",
     "\n",
-    "trace1 = go.Scatter(x=[1,2,3], y=[4,5,6], marker={'color': 'red', 'symbol': 104, 'size': \"10\"}, \n",
+    "trace1 = go.Scatter(x=[1,2,3], y=[4,5,6], marker={'color': 'red', 'symbol': 104, 'size': 10}, \n",
     "                    mode=\"markers+lines\",  text=[\"one\",\"two\",\"three\"], name='1st Trace')\n",
     "                                               \n",
     "data=go.Data([trace1])\n",
@@ -221,9 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "#### The Source of Plotly's Power\n",
     "\n",
@@ -531,9 +529,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "##### Shapes\n",
     "\n",
@@ -672,9 +668,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "The first neat option about using graph_objs is that you can call help on them."
    ]
@@ -974,9 +968,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": []
   },
   {
@@ -1350,18 +1342,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "### Looking at Examples"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "Examples are one of the best ways to get started and get your feet wet. Through the examples you can get a good idea of what a certain type of plot is used for, and what can be possible with it. \n",
     "\n",
@@ -1651,18 +1639,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "### Using the Reference Page"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "At this point you may have a good idea of how you want to visualize your data, and which type of plot you would like to use. You've taken a look at some examples of this plot type, but there are still some details that you would like to add or change. Now is the time for you to check out the **[Reference Page!](https://plot.ly/python/reference/)** The reference page details all the parameters that can be set for every type of plot that is possible in Plotly (ie: all the trace objects). In addition it also provides details on the possible parameters that are available to change in the `Layout` object as well.\n",
     "\n",
@@ -1729,7 +1713,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already up-to-date: publisher in /Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages\r\n"
+      "Requirement already up-to-date: publisher in /Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages\n"
      ]
     }
    ],
@@ -1761,23 +1745,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Line 51 was passing the `"10"` as a string when Scatter would like it as a number.