### PR TITLE
Fix code indentation

### DIFF
--- a/_posts/plotly_js/scientific/contour/2017-08-29-contour-line-labels.html
+++ b/_posts/plotly_js/scientific/contour/2017-08-29-contour-line-labels.html
@@ -9,23 +9,22 @@ arrangement: horizontal
 ---
 
 var data = [ {
-		z: [[10, 10.625, 12.5, 15.625, 20],
-    [5.625, 6.25, 8.125, 11.25, 15.625],
-    [2.5, 3.125, 5.0, 8.125, 12.5],
-    [0.625, 1.25, 3.125, 6.25, 10.625],
-    [0, 0.625, 2.5, 5.625, 10]],
-		type: 'contour',
-    contours: {
-      coloring: 'heatmap',
-		  showlabels: true,
-      labelfont: {
-        family: 'Raleway',
-        size: 12,
-        color: 'white',
-      }
+  z: [[10, 10.625, 12.5, 15.625, 20],
+      [5.625, 6.25, 8.125, 11.25, 15.625],
+      [2.5, 3.125, 5.0, 8.125, 12.5],
+      [0.625, 1.25, 3.125, 6.25, 10.625],
+      [0, 0.625, 2.5, 5.625, 10]],
+  type: 'contour',
+  contours: {
+    coloring: 'heatmap',
+    showlabels: true,
+    labelfont: {
+      family: 'Raleway',
+      size: 12,
+      color: 'white',
     }
-	}
-];
+  }
+}];
 
 var layout = {
   title: 'Contour with Labels'


### PR DESCRIPTION
I just noticed this while browsing the docs.

I've updated the code but will clone and run jekyll shortly to check if it compiles.

EDIT: after waiting so long for the clone and forgetting about it, I finally tested my fix locally. There are many liquid syntax errors in the console but they are also there on the source branch and don't seem related to my fix.