### PR TITLE
Plotly.js Function Reference typo

### DIFF
--- a/_posts/reference_pages/2016-06-03-plotly_js_function_ref.html
+++ b/_posts/reference_pages/2016-06-03-plotly_js_function_ref.html
@@ -108,7 +108,7 @@ var layoutRetrievedLater = graphDiv.layout;
 
 <code>Plotly.react</code> has the same signature as <a href="#plotlynewplot"><code>Plotly.newPlot</code></a> above, and can be used in its place to create a plot, but when called again on the same <code>&lt;div&gt;</code> will update it far more efficiently than <a href="#plotlynewplot"><code>Plotly.newPlot</code></a>, which would destroy and recreate the plot. <code>Plotly.react</code> is as fast as <code>Plotly.restyle</code>/<code>Plotly.relayout</code> documented below.
 <br /><br />
-Important Note: In order to use this method to plot new items in arrays under <code>data</code> such as <code>x</code> or <code>marker.color</code> etc, these items must either have been added immutably (i.e. the identity of the parent array must have changed) or the the value of <a href="{{ BASE_URL }}/javascript/reference/#layout-datarevision"><code>layout.datarevision</code></a> must have changed.
+Important Note: In order to use this method to plot new items in arrays under <code>data</code> such as <code>x</code> or <code>marker.color</code> etc, these items must either have been added immutably (i.e. the identity of the parent array must have changed) or the value of <a href="{{ BASE_URL }}/javascript/reference/#layout-datarevision"><code>layout.datarevision</code></a> must have changed.
 
 <h4 id="plotly-plot"><a href="{{ BASE_URL }}/javascript/plotlyjs-function-reference/#plotlyplot">Plotly.plot</a></h4>
 


### PR DESCRIPTION
https://github.com/plotly/documentation/blob/883cf59f7a7b5dbc026152fb682ed7ba6cb31f5b/_posts/reference_pages/2016-06-03-plotly_js_function_ref.html#L111

> or **the the** value of