### PR TITLE
escape xml in example code blocks

### DIFF
--- a/_includes/auto_examples.html
+++ b/_includes/auto_examples.html
@@ -12,7 +12,7 @@
           {% endif %}
           {% if example.content != "" %}
             <div class="z-depth-1">
-              <pre><code class="{{page.language}}">{{ example.content }}</code></pre>
+              <pre><code class="{{page.language}}">{{ example.content | xml_escape }}</code></pre>
             </div>
           {% endif %}
           {% if example.description %}


### PR DESCRIPTION
resolves #967 by escaping html in all example codeblocks.