### PR TITLE
Correction required in array slicing for frq & Y

### DIFF
--- a/_posts/matplotlib/fft/2015-04-09-mpl-basic-fft.html
+++ b/_posts/matplotlib/fft/2015-04-09-mpl-basic-fft.html
@@ -24,10 +24,10 @@ n = len(y) # length of the signal
 k = np.arange(n)
 T = n/Fs
 frq = k/T # two sides frequency range
-frq = frq[range(n/2)] # one side frequency range
+frq = frq[range(int(n/2))] # one side frequency range
 
 Y = np.fft.fft(y)/n # fft computing and normalization
-Y = Y[range(n/2)]
+Y = Y[range(int(n/2))]
 
 fig, ax = plt.subplots(2, 1)
 ax[0].plot(t,y)


### PR DESCRIPTION
`frq = frq[range(n/2)]` and `Y = Y[range(n/2)]` showed `TypeError` with the following message:
`'float' object cannot be interpreted as an integer`. 
Since `150/2 = 75.0` which is a float and slicing require integer as index. Thus made relevant changes in `line 27 and 30`.