### PR TITLE
add layout attributes to reference page for sunburst, waterfall and pie

### DIFF
--- a/_includes/plotschema-reference.html
+++ b/_includes/plotschema-reference.html
@@ -73,6 +73,21 @@
             {% assign attribute=site.data.plotschema.schema.traces.violin.layoutAttributes %}
             {% assign block = "layout" %}
             {% include reference-block.html parentlink=localparentlink block=block %}
+
+            {% assign localparentlink="layout" %}
+            {% assign attribute=site.data.plotschema.schema.traces.waterfall.layoutAttributes %}
+            {% assign block = "layout" %}
+            {% include reference-block.html parentlink=localparentlink block=block %}
+
+            {% assign localparentlink="layout" %}
+            {% assign attribute=site.data.plotschema.schema.traces.pie.layoutAttributes %}
+            {% assign block = "layout" %}
+            {% include reference-block.html parentlink=localparentlink block=block %}
+
+            {% assign localparentlink="layout" %}
+            {% assign attribute=site.data.plotschema.schema.traces.sunburst.layoutAttributes %}
+            {% assign block = "layout" %}
+            {% include reference-block.html parentlink=localparentlink block=block %}
     </div>
 </div>
 


### PR DESCRIPTION
update resolution from #202 for newer trace types.