### PR TITLE
hovertemplate js add .text to *axis.title accounts for plotly title obj

### DIFF
--- a/_posts/plotly_js/chart-events/hover/2019-05-15-advanced-hovertemplate.html
+++ b/_posts/plotly_js/chart-events/hover/2019-05-15-advanced-hovertemplate.html
@@ -38,8 +38,8 @@ Plotly.d3.csv(
           transforms: [{ type: "groupby", groups: c }],
           hovertemplate:
             "<b>%{text}</b><br><br>" +
-            "%{yaxis.title}: %{y:$,.0f}<br>" +
-            "%{xaxis.title}: %{x:.0%}<br>" +
+            "%{yaxis.title.text}: %{y:$,.0f}<br>" +
+            "%{xaxis.title.text}: %{x:.0%}<br>" +
             "Number Employed: %{marker.size:,}" +
             "<extra></extra>"
         }


### PR DESCRIPTION
Otherwise <object> appears in the hovertext instead of the title