### PR TITLE
Update mentions of ipython notebooks to jupyter.

### DIFF
--- a/_posts/python/README.md
+++ b/_posts/python/README.md
@@ -1,6 +1,6 @@
 # Contribute to Plotly's [Python Documentation](https://plot.ly/python/)
-## Initial Steps:
-1. Clone the repo and then check out the source-design-merge branch:
+## Initial Steps
+1. Clone the repo and then check out the `source-design-merge` branch:
 
   ```
   $ git clone git@github.com:plotly/documentation.git
@@ -8,23 +8,23 @@
   $ git checkout source-design-merge
   ```
 
-2. Check Ruby version `$ ruby --version`. We recommend using `version 2.3.3` or the same ruby version as gh-pages: https://pages.github.com/versions/. Note [RVM](https://rvm.io/rvm/install) is helpful for installing and managing ruby versions.
+2. Check your ruby version with `$ ruby --version`. We recommend using `version 2.3.3` or the same ruby version as GitHub Pages: https://pages.github.com/versions/. Note that [RVM](https://rvm.io/rvm/install) is helpful for installing and managing ruby versions.
 
-3. Install bundler and a couple dependencies from the gemfile:
+3. Install bundler and a couple of dependencies from the Gemfile:
 
   ```
   $ gem install bundler
   $ bundle install
 
   ```
-<b>IMPORTANT</b> -If not using bundler and the gemfile, [install the same jekyll version that GitHub Pages is using](https://pages.github.com/versions/).
+<b>IMPORTANT</b> If not using bundler and the Gemfile, install the same jekyll version [as used by GitHub Pages](https://pages.github.com/versions/).
 
-## Create Python Documentation:
-Our python tutorials are written in [ipython notebooks](http://ipython.org/notebook.html) (.ipynb file)
-##### In `documentation/_posts/python`
+## Create Python Documentation
+Our python tutorials are written as [jupyter notebooks](https://jupyter.readthedocs.io/en/latest/running.html) (`.ipynb` files).
+##### In `documentation/_posts/python/`
 1. Create a folder titled with the chart type or topic you're adding to the documentation (i.e. `table`)  
-2. `cd` into the folder you created and run `ipython notebook`
-  - From the <b>New</b> dropdown create a new notebook and title it based on the type of chart you're adding to the documentation.
+2. `cd` into the folder you created and run `jupyter notebook`
+  - Using the <b>New</b> dropdown, create a new notebook and title it based on the type of chart you're adding to the documentation.
 3. Base your tutorial structure off of one of our existing tutorials (i.e. `documentation/_posts/python/table/table.ipynb`)
 4. The first cell should be a markdown cell with the following text:
 
@@ -35,7 +35,7 @@ Our python tutorials are written in [ipython notebooks](http://ipython.org/noteb
     <br>We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/python_cheat_sheet.pdf) (new!) to help you get started!
     ```
 
-5. **IF** you're adding a doc about a new feature, the second and third cells will display a version check. This is to ensure the reader has updated to the necessary version. This is especially applicable to FigureFactory docs. You can refer to the python api [CHANGELOG](https://github.com/plotly/plotly.py/blob/master/CHANGELOG.md) to check the appropriate version #. Example of a version check:   
+5. **If** you're adding a doc about a new feature, the second and third cells should display a version check. This is to ensure the reader has updated to the necessary version. This is especially applicable to FigureFactory docs. You can refer to the python API [CHANGELOG](https://github.com/plotly/plotly.py/blob/master/CHANGELOG.md) to check the appropriate version. Example of a version check:
   - markdown cell:
       ```
       #### Version Check
@@ -49,10 +49,10 @@ Our python tutorials are written in [ipython notebooks](http://ipython.org/noteb
       ```
 
 6. Best Practices:
-  - <b>Now we have an awesome navigation bar on the left side of our tutorial pages.</b> The navigation bar displays the headers you add to your notebook so add a header for each example and try to make headers as informative and concise as possible. Furthermore, capitalize all headers (except for `code`). Ex: `#### Basic Line Chart`
-  - Order examples from basic -> advanced.
+  - <b>Now we have an awesome navigation bar on the left side of our tutorial pages.</b> The navigation bar displays the headers you add to your notebook, so add a header for each example and make headers as informative and concise as possible. Furthermore, capitalize all headers (except for `code`), e.g. `#### Basic Line Chart`.
+  - Order examples from basic to advanced.
   - Run examples with user: `PythonPlotBot`
-  - Keep import order consistent and import plotly packages first, then a space, then additional packages. For example:
+  - Keep import order consistent and import plotly packages first, then skip a line, and import additional packages. For example:
 
     ```
     import plotly.plotly as py
@@ -62,10 +62,10 @@ Our python tutorials are written in [ipython notebooks](http://ipython.org/noteb
     import numpy as np
     ```
 
-  - Try and write all of the code for a given example in a *single* ipython notebook cell. This makes it easier for users to use the `copy to clipboard` button that appears on the codeblocks and easily/quickly reproduce each example.
-  - If you're using "real" data, upload the datafile to https://github.com/plotly/datasets then import data rather than pasting a large chunk of data in the tutorial. (Using random data is okay for some examples too :) )
+  - Try and write all of the code for a given example in a *single* jupyter notebook cell. This makes it easier for users to use the `copy to clipboard` button that appears on the codeblocks and easily/quickly reproduce each example.
+  - If you're using "real" data, upload the datafile to https://github.com/plotly/datasets then import it rather than pasting a large chunk of data in the tutorial. Using random data is okay for some examples too :)
 
-7. The last content cell of your notebook should be a markdown cell with:
+7. The last cell of your notebook should be a markdown cell containing:
 
     ```
     #### Reference
@@ -73,13 +73,12 @@ Our python tutorials are written in [ipython notebooks](http://ipython.org/noteb
     ```
 
   where `https://plot.ly/python/reference/##heatmap` is replaced with the pertinent link(s) to our python [reference
-  page](https://plot.ly/python/reference/)!
+  page](https://plot.ly/python/reference/)
+  and/or a help call:
+    `help(FF.create_table)` (the latter applies to documentation on FigureFactory functions).
 
-  and/or provide a help call:
-    `help(FF.create_table)` (*This applies to documentation on FigureFactory functions)
-
-8. Convert your .ipynb to a .html file by adding the following code snippet as the last cell of your notebook.
-  - Replace `your-tutorial-chart` with the type of chart you're creating in the tutorial.)
+8. Convert your .ipynb file to an .html file by adding the following code snippet as the last cell of your notebook (publisher cell):
+  - Replace `your-tutorial-chart` with the type of chart you're creating in the tutorial;
   - Please be diligent about adding this information completely and in the order as it appears here (this is really helpful if future edits are necessary :D )
 
   ```
@@ -98,9 +97,9 @@ Our python tutorials are written in [ipython notebooks](http://ipython.org/noteb
       language='python',
       # page_type='example_index', // note this is only if you want the tutorial to appear on the main page: plot.ly/python
       display_as='chart_type', order=2, ipynb='~notebook_demo/1',
-      uses_plotly_offline=False*)
+      uses_plotly_offline=False)
   ```
-  - always include a trailing slash in the permalink (i.e. python/your-tutorial-chart/)
+  - always include a trailing slash in the permalink (i.e. `python/your-tutorial-chart/`)
   - `display_as` sets in which section your tutorial is displayed
     - 'basic' = https://plot.ly/python/#basic-charts
     - 'statistical' = https://plot.ly/python/#statistical-charts
@@ -108,30 +107,30 @@ Our python tutorials are written in [ipython notebooks](http://ipython.org/noteb
     - 'financial' = https://plot.ly/python/#financial-charts
     - 'maps' = https://plot.ly/python/#maps
     - '3d_charts' = https://plot.ly/python/#3d-charts
-    - See additional options [HERE](https://github.com/plotly/documentation/blob/source-design-merge/_includes/documentation_eg.html#L1)
-  - `order` defines the order in which the tutorials appear on plot.ly/python. Please take a look at https://plot.ly/python/ and order your tutorial next to similar chart types. <b>Note</b> `order` can be a float.
-  - `uses_plotly_offline` is an optional argument, include as `True` if you're creating an offline doc.
+    - See additional options [here](https://github.com/plotly/documentation/blob/source-design-merge/_includes/documentation_eg.html#L1)
+  - `order` defines the order in which the tutorials appear online. Please take a look at https://plot.ly/python/ and order your tutorial next to similar chart types. <b>Note</b> that `order` can be a float.
+  - `uses_plotly_offline` is an optional argument, set to `True` if you're creating an offline doc.
 
-9. Now we can upload/download jupyter (ipython) notebooks to Plotly!!!!
-  - There is a button in our side navigation bar of the python docs so users can click the button and see the notebook hosted on plot.ly where they can download it and run it to follow along with the documentation.
+9. Now we can upload/download jupyter (ipython) notebooks to Plotly!!!
+  - There is a button in the side navigation bar of the python docs that users can click to see the notebook, download it, and run it to follow along with the documentation.
   - Use the bubble chart doc: https://plot.ly/python/bubble-charts/ as an example.
-  - Here are step by step instructions of how to enable the `Download THIS Notebook` button:
+  - Here are step-by-step instructions on how to enable the `Download THIS Notebook` button:
     1. Copy the notebook from the folder. For example from the [bubble folder](https://github.com/plotly/documentation/tree/source-design-merge/_posts/python/bubble), copy `bubble.ipynb`.
-    2. Run `ipython notebook` or `jupyter notebook` and remove the publisher cell from your copy. (The publisher cell is the last cell that we add to our doc notebooks to convert the `.ipynb` to `html`. We do not need to upload this. _Do not remove this cell from the .ipynb in the doc repo_). Save.
+    2. Run `jupyter notebook` and remove the publisher cell from your copy. (The publisher cell is the last cell that we add to our doc notebooks to convert them from `.ipynb` to `html`. We do not need to upload this. _Do not remove this cell from the .ipynb in the doc repo_.) Save.
     3. Upload the copy to the `notebook_demo` Plotly account.
-    4. View the notebook: the link is: https://plot.ly/~notebook_demo/1/new-to-plotly-plotlys-python-library-i/ Grab the username + file id # from the link: `~notebook_demo/1` and add it to the publisher cell in the original .ipynb file in the doc repo. See example publisher cell below.
+    4. View the notebook: the link is: https://plot.ly/~notebook_demo/1/new-to-plotly-plotlys-python-library-i/ Grab the username + file id # from the link: `~notebook_demo/1` and add it to the publisher cell in the original `.ipynb` file in the doc repo. See example publisher cell above.
 
-10. Add Thumbnail Images
-  - Thumbnail images should named `your-tutorial-chart.jpg` and be *EXACTLY* 160px X 160px
-  - Thumbnail images should be clear and interesting. You do not need to capture the ENTIRE chart, but rather focus on the most interesting part of the chart.
+10. Add thumbnail images:
+  - Thumbnail images should be named `your-tutorial-chart.jpg` and be **exactly** 160px X 160px.
+  - Thumbnail images should be clear and interesting. You do not need to capture the entire chart, but rather focus on the most interesting part of the chart.
   - Use images.plot.ly for adding new images.
     - Log-in here: https://661924842005.signin.aws.amazon.com/console
     - Username: Plotly_Editors
     - From the <b>Amazon Web Services Console</b> select <b>S3 (Scalable Storage in the Cloud)</b> then select <b>plotly-tutorials</b> -> <b>plotly-documentation</b> -> <b>thumbnail</b>
-    - Now from <b>All Buckets /plotly-tutorials/plotly-documentation/thumbnail</b> select the <b>Actions</b> dropdown and <b>upload</b> your .jpg file
+    - Now from <b>All Buckets /plotly-tutorials/plotly-documentation/thumbnail</b> select the <b>Actions</b> dropdown and <b>upload</b> your .jpg file.
 
-##### In the terminal in `documentation`
-9. Make a PR
+##### Back in the terminal in `documentation/`
+11. Submit a PR
 
   - Ready for your changes to be reviewed? Make a pull request against the `source-design-merge` branch!
   Create a feature branch and use `git status` to list changed files.
@@ -148,14 +147,14 @@ Our python tutorials are written in [ipython notebooks](http://ipython.org/noteb
   ```
   - Visit the [documentation repo](https://github.com/plotly/documentation) and open a pull request against the `source-design-merge` branch. You can then tag **@cldougl** and **@bcdunbar** for a review.
 
-10. To proof your work follow these steps: https://github.com/plotly/documentation/blob/source/Contributing.md#rendering-the-pages-locally
+12. To proof your work follow these steps: https://github.com/plotly/documentation/blob/source/Contributing.md#rendering-the-pages-locally
 
 ##### At https://plot.ly/python
-11. Your changes haven't been deployed yet so they won't be online. That said, <b>PLEASE</b> visit https://plot.ly/python/your-tutorial and make sure everything looks correct once they have been deployed by either **@cldougl** or **@bcdunbar**.
+13. Your changes haven't been deployed yet so they won't be online. That said, <b>PLEASE</b> visit https://plot.ly/python/your-tutorial and make sure everything looks correct once they have been deployed by either **@cldougl** or **@bcdunbar**.
 
   - Some common problems that you should check for:
-    - Make sure all plots appear! (*you may want to sign out of your Plotly account to ensure you didn't accidentally embed private plots)
-    - There are no empty notebook cells
+    - Make sure all plots appear! (You may want to sign out of your Plotly account to ensure you didn't accidentally embed private plots.)
+    - There are no empty notebook cells.
     - The thumbnail image appears on: https://plot.ly/python/
 
 ## Search


### PR DESCRIPTION
Hi,

I was about to suggest minor changes to one of the doc notebooks, which led to the README for python docs.

I mainly suggest dropping `ipython` in favour of `jupyter`; otherwise, I fixed some inconsistencies in style or wording.

/cc @bcdunbar @nicolaskruchten 