### PR TITLE
typecast map to list in cmocean notebook

### DIFF
--- a/_posts/python-v3/advanced/cmocean/cmocean.ipynb
+++ b/_posts/python-v3/advanced/cmocean/cmocean.ipynb
@@ -61,7 +61,7 @@
     "    pl_colorscale = []\n",
     "    \n",
     "    for k in range(pl_entries):\n",
-    "        C = map(np.uint8, np.array(cmap(k*h)[:3])*255)\n",
+    "        C = list(map(np.uint8, np.array(cmap(k*h)[:3])*255))\n",
     "        pl_colorscale.append([k*h, 'rgb'+str((C[0], C[1], C[2]))])\n",
     "        \n",
     "    return pl_colorscale"


### PR DESCRIPTION
Fixes typo/missing typecast that otherwise raises TypeError: 'map' object is not subscriptable