### PR TITLE
Remove breadcrumbs and additonal navigation on landing page of /api

### DIFF
--- a/_posts/2015-07-26-index.html
+++ b/_posts/2015-07-26-index.html
@@ -31,7 +31,6 @@ permalink: /api/
                 </div>
             </div>
         </section>
-        {% include breadcrumb.html %}
 
         <section class="--documentation-categories">
             <div class="--wrap category-buttons">
@@ -137,99 +136,6 @@ permalink: /api/
                         </a>
                     </li>
                 </ul>
-            </div>
-        </section>
-
-        <!-- SCIENTIFIC GRAPHING -->
-        <section class="--more-categories">
-            <header>
-                <div class="--wrap">
-                    <h4>Additional Resources</h4>
-                </div>
-            </header>
-            <div class="--wrap">
-                <article class="sub-section">
-                    <header>
-                        <h5>Python</h5>
-                    </header>
-                    <ul>
-                        <li><a href="/python/" class="button no_underline centeredsmall">Python</a></li>
-                        <li><a href="https://plot.ly/dash" class="button no_underline centeredsmall">Dash - Python Web Applications</a></li>
-                        <li><a href="/ipython-notebooks/gallery" class="button no_underline centeredsmall">IPython
-                            Notebook</a></li>
-                        <li><a href="/matplotlib/" class="button no_underline centeredsmall">matplotlib</a></li>
-                        <li><a href="/pandas/" class="button no_underline centeredsmall">pandas</a></li>
-                    </ul>
-                </article>
-                <article class="sub-section">
-                    <header>
-                        <h5>R</h5>
-                    </header>
-                    <ul>
-                        <li><a href="/r/" class="button no_underline centeredsmall">R</a></li>
-                        <li><a href="/r/shiny-tutorial/" class="button no_underline centeredsmall">R Shiny</a></li>
-                        <li><a href="/ggplot2/" class="button no_underline centeredsmall">ggplot2</a></li>
-                    </ul>
-                </article>
-                <article class="sub-section">
-                    <header>
-                        <h5>Others</h5>
-                    </header>
-                    <ul>
-                        <li><a href="/matlab/" class="button no_underline centeredsmall">MATLAB</a></li>
-                        <li><a href="/julia/" class="button no_underline centeredsmall">Julia</a></li>
-                        <li><a href="/scala/" class="button no_underline centeredsmall">Scala</a></li>
-                        <li><a href="https://github.com/plotly/Igor-Pro-Graph-Converter"
-                               class="button no_underline centeredsmall">Igor Pro</a></li>
-                        <li><a href="https://github.com/plotly/spotfire"
-                               class="button no_underline centeredsmall">Spotfire</a></li>
-                    </ul>
-                </article>
-            </div>
-
-        </section>
-
-        <!-- WEB CHARTING -->
-
-        <section class="--more-categories">
-            <div class="--wrap">
-                <article class="sub-section">
-                    <header>
-                        <h4>Websites</h4>
-                    </header>
-                    <p>Serve plot iframes, JavaScript, or images to your website or app.</p>
-                    <ul>
-                        <li><a href="/javascript/" class="button no_underline centeredsmall">JavaScript</a></li>
-                        <li><a href="/python/" class="button no_underline centeredsmall">Python</a></li>
-                        <li><a href="/nodejs/" class="button no_underline centeredsmall">Node.js</a></li>
-                        <li><a href="https://github.com/plotly/ruby-api"
-                               class="button no_underline centeredsmall">Ruby</a></li>
-                        <li><a href="https://github.com/plotly/golang-api"
-                               class="button no_underline centeredsmall">Go</a></li>
-                        <li><a href="http://tahahachana.github.io/XPlot/"
-                               class="button no_underline centeredsmall">F#</a></li>
-                    </ul>
-                </article>
-
-                <!-- HARDWARE -->
-
-                <article class="sub-section">
-                    <header>
-                        <h4>Hardware and Embedded Systems</h4>
-                    </header>
-                    <p style="margin-top:5px;">Stream sensor data to graphs.</p>
-                    <ul>
-                        <li>
-                            <a href="http://adilmoujahid.com/posts/2015/07/practical-introduction-iot-arduino-nodejs-plotly/"
-                               class="button no_underline centeredsmall">Arduino</a></li>
-                        <li><a href="https://plot.ly/raspberry-pi/tmp36-temperature-tutorial/"
-                               class="button no_underline centeredsmall">Rasberry Pi</a></li>
-                        <li><a href="https://www.dashdaq.io/" class="button no_underline centeredsmall">Plotly
-                            DASH DAQ</a></li>
-                    </ul>
-                </article>
-
-
             </div>
         </section>
     </div>


### PR DESCRIPTION
This PR partially addresses https://github.com/plotly/documentation/issues/1425

- [x] remove breadcrumbs from landing page
- [x] remove additional resources section from landing page