### PR TITLE
removing 20px of margin-top from lang-splash-banner component

### DIFF
--- a/_includes/lang-splash-banner.html
+++ b/_includes/lang-splash-banner.html
@@ -1,1 +1,1 @@
-<div style="margin-top: 100px"></div>
+<div style="margin-top: 80px"></div>


### PR DESCRIPTION
closes https://github.com/plotly/documentation/issues/1424

![breadcrumb](https://user-images.githubusercontent.com/1557650/62706728-1d6b3200-b9be-11e9-8b4f-04e98c7544b6.gif)
