### PR TITLE
syncing footer urls with plotly/next

### DIFF
--- a/_includes/_new/_page-components/_footer-main.html
+++ b/_includes/_new/_page-components/_footer-main.html
@@ -36,10 +36,9 @@
                     <li class="--footer-column">
                         <h6 style="color:#EF553B" class="--footer-heading">Support</h6>&#x9;&#x9;&#x9;
                         <ul>
-                            <li><a href="https://support.plot.ly/" target="_self">Developer Support</a></li>
                             <li><a href="https://community.plot.ly/" target="_self">Community Support</a></li>
                             &#x9;&#x9;&#x9;&#x9;
-                            <li><a href="https://help.plot.ly/" target="_self">Documentation</a></li>
+                            <li><a href="https://plot.ly/graphing-libraries" target="_self">Documentation</a></li>
                             &#x9;&#x9;&#x9;&#x9;
                         </ul>
                     </li>

--- a/_includes/_new/_page-components/_footer-main.html
+++ b/_includes/_new/_page-components/_footer-main.html
@@ -9,7 +9,7 @@
                             &#x9;&#x9;&#x9;&#x9;
                             <li><a href="https://plot.ly/online-chart-maker/" target="_self">Chart Studio</a></li>
                             &#x9;&#x9;&#x9;&#x9;
-                            <li><a href="https://plot.ly/products/pricing/" target="_self">Plotly OEM</a></li>
+                            <li><a href="https://plot.ly/products/oem/" target="_self">Plotly OEM</a></li>
                         </ul>
                     </li>
                     &#x9;&#x9;
@@ -26,7 +26,9 @@
                         <ul>
                             <li><a href="https://plot.ly/company/careers" target="_self">Careers</a></li>
                             &#x9;&#x9;&#x9;&#x9;
-                            <li><a href="https://plot.ly/newsroom" target="_self">Newsroom</a></li>
+                            <li><a href="https://plot.ly/resources/" target="_self">Resources</a></li>
+                            &#x9;&#x9;&#x9;&#x9;
+                            <li><a href="https://medium.com/@plotlygraphs" target="_self">Blog</a></li>
                             &#x9;&#x9;&#x9;&#x9;
                         </ul>
                     </li>
@@ -34,11 +36,11 @@
                     <li class="--footer-column">
                         <h6 style="color:#EF553B" class="--footer-heading">Support</h6>&#x9;&#x9;&#x9;
                         <ul>
+                            <li><a href="https://support.plot.ly/" target="_self">Developer Support</a></li>
                             <li><a href="https://community.plot.ly/" target="_self">Community Support</a></li>
                             &#x9;&#x9;&#x9;&#x9;
-                            <li><a href="https://plot.ly/graphing-libraries" target="_self">Documentation</a></li>
+                            <li><a href="https://help.plot.ly/" target="_self">Documentation</a></li>
                             &#x9;&#x9;&#x9;&#x9;
-
                         </ul>
                     </li>
                     &#x9;&#x9;


### PR DESCRIPTION
This PR syncs  the footer URLs in this repo with those in `plotly-next`. 

This should have been accomplished by https://github.com/plotly/documentation/pull/1438 but either I made a mistake or the URLs have changed in the interim, or both. 

<img width="1425" alt="Screen Shot 2019-08-20 at 2 07 22 PM" src="https://user-images.githubusercontent.com/1557650/63372673-95d5d980-c354-11e9-815e-27efd0c685c8.png">
