### PR TITLE
Remove whitespace output from for loops.

### DIFF
--- a/_includes/layouts/side-bar.html
+++ b/_includes/layouts/side-bar.html
@@ -24,7 +24,7 @@
 
 {% assign pages_list = site.posts | where:"language", language %}
 
-{% for page in pages_list %}
+{%- for page in pages_list -%}
 {% if page.display_as == "chart_type" or page.display_as == "basic" %}
 {% assign basic = true %}
 {% elsif page.display_as == "file_settings" %}
@@ -83,7 +83,7 @@
 {% assign theme = true %}
 <!-- END OF GGPLOT CUSTOM LAYOUT -->
 {% endif %}
-{% endfor %}
+{%- endfor -%}
 
 
 <aside class="--sidebar-container">

--- a/_includes/posts/auto_examples.html
+++ b/_includes/posts/auto_examples.html
@@ -1,5 +1,5 @@
 {% assign counter = 0 %} 
-{% for example in examples %}
+{%- for example in examples -%}
   {% assign counter=counter | plus:1 %}
     <div class="section">
       <div class="row auto-eg-padding">
@@ -50,5 +50,5 @@
           {% endif %}
         </div>
     </div>
-{% endfor %}
+{%- endfor -%}
 

--- a/_includes/posts/documentation_eg.html
+++ b/_includes/posts/documentation_eg.html
@@ -1,5 +1,5 @@
 {% comment %}First, check which sections this page should contain checking all of the posts{% endcomment %}
-{% for page in languagelist %}
+{%- for page in languagelist -%}
 {% if page.display_as == "file_settings" %}
 {% assign file_settings = true %}
 {% elsif page.display_as == "chart_type" or page.display_as == "basic" %}
@@ -46,10 +46,10 @@
 {% assign theme = true %}
 <!-- END OF GGPLOT CUSTOM LAYOUT -->
 {% endif %}
-{% endfor %}
+{%- endfor -%}
 
 {% comment %} these are the pages that don't have images to show {% endcomment %}
-{% for page in languagelist %}
+{%- for page in languagelist -%}
 {% if page.display_as == "layout_opt" %}
 {% assign layout_options = true %}
 {% elsif page.display_as == "style_opt" %}
@@ -75,7 +75,7 @@
 {% elsif page.display_as == "text_documents" %}
 {% assign text_documents = true %}
 {% endif %}
-{% endfor %}
+{%- endfor -%}
 
 {% include both/py4_note.html %}
 
@@ -87,7 +87,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "file_settings" %}
 
 
@@ -103,7 +103,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -115,7 +115,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "chart_type" or page.display_as == "basic" %}
 
 
@@ -131,7 +131,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -147,7 +147,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "statistical" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -165,7 +165,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -177,7 +177,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "scientific" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -195,7 +195,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -207,7 +207,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "financial" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -225,7 +225,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -237,7 +237,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "maps" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -255,7 +255,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -267,7 +267,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "3d_charts" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -285,7 +285,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -297,7 +297,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "multiple_axes" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -315,7 +315,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -327,7 +327,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "chart_events" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -345,7 +345,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -357,7 +357,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "chart_events" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -375,7 +375,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -387,7 +387,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "chart_events" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -405,7 +405,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -417,7 +417,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "transforms" %}
 
 
@@ -433,7 +433,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -445,7 +445,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "controls" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -463,7 +463,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -475,7 +475,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "animations" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -493,7 +493,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -505,7 +505,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "chart_studio" %}
 
 
@@ -521,7 +521,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -533,7 +533,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "financial_analysis" %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -551,7 +551,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -566,13 +566,13 @@
 <ul >
 
 {% assign counter=0 %}
-{% for page in languagelist %}
+{%- for page in languagelist -%}
 {% if page.display_as == "layout_opt" %}
 {% if counter == 6 %}</ul></div><div class="six columns"><ul>{% endif %}
 <li><a class="no-list-style" href="/{{page.permalink}}">{{page.name}}</a></li>
 {% assign counter=counter | plus:1 %}
 {% endif %}
-{% endfor %}
+{%- endfor -%}
 </ul>
 </div>
 </div>
@@ -592,7 +592,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "advanced_opt" %}
 
             <li class="--grid-item">
@@ -602,7 +602,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -615,7 +615,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "style_opt" %}
 
             <li class="--grid-item">
@@ -625,7 +625,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -638,7 +638,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "layout_opt" %}
 
             <li class="--grid-item">
@@ -648,7 +648,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -661,7 +661,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "legacy_charts" %}
 
             <li class="--grid-item">
@@ -671,7 +671,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -684,7 +684,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "databases" %}
 
             <li class="--grid-item">
@@ -695,7 +695,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -708,7 +708,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "report_generation" %}
 
             <li class="--grid-item">
@@ -719,7 +719,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -736,7 +736,7 @@
         </p>
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "chart_events" %}
 
             <li class="--grid-item">
@@ -747,7 +747,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -760,7 +760,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "tutorial" %}
 
             <li class="--grid-item">
@@ -770,7 +770,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -783,7 +783,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "get_request" %}
 
             <li class="--grid-item">
@@ -793,7 +793,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -806,7 +806,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "mathematics" %}
 
             <li class="--grid-item">
@@ -816,7 +816,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -830,7 +830,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "statistics" %}
 
             <li class="--grid-item">
@@ -840,7 +840,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -853,7 +853,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "peak-analysis" %}
 
             <li class="--grid-item">
@@ -863,7 +863,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -876,7 +876,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {% assign counter=0 %}
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "signal-analysis" %}
 
             <li class="--grid-item">
@@ -886,7 +886,7 @@
             </li>
             {% assign counter=counter | plus:1 %}
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -901,7 +901,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "aesthetics" %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -915,7 +915,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -929,7 +929,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "geoms" %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -943,7 +943,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -956,7 +956,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "faceting" %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -970,7 +970,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -983,7 +983,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "other" %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -997,7 +997,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -1012,7 +1012,7 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {% for page in languagelist %}
+            {%- for page in languagelist -%}
             {% if page.display_as == "theme" %}
 
 
@@ -1028,7 +1028,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>

--- a/_includes/posts/plotschema-reference.html
+++ b/_includes/posts/plotschema-reference.html
@@ -1,6 +1,6 @@
 {% capture plotschemacontent %}
 
-{% for trace in site.data.plotschema.traces %}
+{%- for trace in site.data.plotschema.traces -%}
 
 <div class="row">
     <div class="eight columns">
@@ -43,7 +43,7 @@
 </div>
 <hr>
 
-{% endfor %}
+{%- endfor -%}
 
 <div class="row">
     <div class="eight columns">


### PR DESCRIPTION
Main pages in view source mode now have less whitespace.  For example the main R page is about half as big as it was previously.  This PR just targeted `for` loops.

refs #1487 