### PR TITLE
changing plotly.js to JavaScript in navigation

### DIFF
--- a/_includes/layouts/breadcrumb.html
+++ b/_includes/layouts/breadcrumb.html
@@ -29,7 +29,7 @@
             <li class="--breadcrumb-item"><a href="/graphing-libraries/"><span>Open Source Graphing Libraries</span></a></li>
             {% if page.permalink != "/api/" %}
             <li class="--breadcrumb-item">
-                <a href="/{% if page.permalink contains 'javascript' %}javascript{% else %}{{page.language}}{% endif %}" {% if page.layout == "langindex" %} class="--current" {% endif %} ><span>{% if page.language == "plotly_js" %}plotly.js{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}Plotly Graphing Library for MATLAB<sup>&reg;</sup>{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}</span></a>
+                <a href="/{% if page.permalink contains 'javascript' %}javascript{% else %}{{page.language}}{% endif %}" {% if page.layout == "langindex" %} class="--current" {% endif %} ><span>{% if page.language == "plotly_js" %}JavaScript{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}Plotly Graphing Library for MATLAB<sup>&reg;</sup>{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}</span></a>
             </li>
             {% endif %}
 

--- a/_includes/layouts/lang-navigation.html
+++ b/_includes/layouts/lang-navigation.html
@@ -56,7 +56,7 @@
                 <a class="lang_nav_button {{plotjsclass}}" href="/javascript{{page_type}}">
 					<div><img src="https://images.plot.ly/language-icons/api-home/js-logo.png" alt="plotly.js" class="lang_nav_thum"></div>
 
-					Javascript
+					JavaScript
                 </a>
             </li>
 		{%- endif -%}

--- a/_includes/layouts/reference-side-nav.html
+++ b/_includes/layouts/reference-side-nav.html
@@ -295,7 +295,7 @@
                                       d="M20,10V14H11L14.5,17.5L12.08,19.92L4.16,12L12.08,4.08L14.5,6.5L11,10H20Z"/>
                             </svg>
                         </div>
-                        <span><a href="/{% if page.language == "plotly_js" %}javascript{% else %}{{page.language}}{% endif %}/">Back to {% if page.language == "plotly_js" %}plotly.js{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}MATLAB{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}
+                        <span><a href="/{% if page.language == "plotly_js" %}javascript{% else %}{{page.language}}{% endif %}/">Back to {% if page.language == "plotly_js" %}JavaScript{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}MATLAB{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}
                         </a></span>
         </button>
     </div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -54,7 +54,7 @@
 									  d="M20,10V14H11L14.5,17.5L12.08,19.92L4.16,12L12.08,4.08L14.5,6.5L11,10H20Z"/>
 							</svg>
 						</div>
-						<span><a href="/{% if page.language == "plotly_js" %}javascript{% else %}{{page.language}}{% endif %}/">Back to {% if page.language == "plotly_js" %}plotly.js{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}Plotly Graphing Library for MATLAB<sup>&reg;</sup>{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}
+						<span><a href="/{% if page.language == "plotly_js" %}javascript{% else %}{{page.language}}{% endif %}/">Back to {% if page.language == "plotly_js" %}JavaScript{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}Plotly Graphing Library for MATLAB<sup>&reg;</sup>{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}
 						</a></span>
 					</button>
 				</nav>
@@ -116,7 +116,7 @@
 
 							{% unless page.ignore_header %}
 							<h1>
-								{{page.name}} in {% if page.language == "plotly_js" %}plotly.js{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}MATLAB<sup>&reg;</sup>{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}
+								{{page.name}} in {% if page.language == "plotly_js" %}JavaScript{% elsif page.language == "ggplot2" %}ggplot2{% elsif page.language == "matlab" %}MATLAB<sup>&reg;</sup>{% elsif page.language == "matplotlib" %}matplotlib{% else %}{{page.language | capitalize}}{% endif %}
 							</h1>
 							<p>{{page.description}} </p>
 

--- a/_posts/plotly_js/3d/3d-isosurface/2019-04-16-isosurface-plotly_js_index.html
+++ b/_posts/plotly_js/3d/3d-isosurface/2019-04-16-isosurface-plotly_js_index.html
@@ -1,5 +1,5 @@
 ---
-title: Javascript Graphing Library 3D Isosurface Plots | Examples | Plotly
+title: JavaScript Graphing Library 3D Isosurface Plots | Examples | Plotly
 name: 3D Isosurface Plots
 permalink: javascript/3d-isosurface-plots/
 description: How to make 3D isosurface plots in javascript.

--- a/_posts/plotly_js/basic/sunburst/2019-04-11-sunburst_plotly_js_index.html
+++ b/_posts/plotly_js/basic/sunburst/2019-04-11-sunburst_plotly_js_index.html
@@ -1,5 +1,5 @@
 ---
-title: Javascript Graphing Library D3.js-based Sunburst Plots | Examples | Plotly
+title: JavaScript Graphing Library D3.js-based Sunburst Plots | Examples | Plotly
 name: Sunburst Charts
 permalink: javascript/sunburst-charts/
 description: How to make a D3.js-based sunburst chart in javascript. Visualize hierarchical data spanning outward radially from root to leaves.

--- a/_posts/plotly_js/financial/funnel/2019-06-27-funnel_plotly_js_index.html
+++ b/_posts/plotly_js/financial/funnel/2019-06-27-funnel_plotly_js_index.html
@@ -1,5 +1,5 @@
 ---
-title: Javascript Graphing Library D3.js-based Funnel Charts | Examples | Plotly
+title: JavaScript Graphing Library D3.js-based Funnel Charts | Examples | Plotly
 name: Funnel and Funnelarea Charts
 permalink: javascript/funnel-charts/
 description: How to make a D3.js-based funnel chart in javascript.

--- a/_posts/plotly_js/financial/waterfall/2015-04-09-bar_plotly_js_index.html
+++ b/_posts/plotly_js/financial/waterfall/2015-04-09-bar_plotly_js_index.html
@@ -1,5 +1,5 @@
 ---
-title: Javascript Graphing Library D3.js-based Bar Charts | Examples | Plotly
+title: JavaScript Graphing Library D3.js-based Bar Charts | Examples | Plotly
 name: Waterfall Charts
 permalink: javascript/waterfall-charts/
 description: How to make a D3.js-based waterfall chart in javascript.

--- a/_posts/reference_pages/2015-08-19-plotly_js-reference.html
+++ b/_posts/reference_pages/2015-08-19-plotly_js-reference.html
@@ -8,7 +8,7 @@ title: plotly.js chart attribute reference
 description: The extensive reference of plotly chart attributes for plotly.js.
 redirect_from: /javascript-graphing-library/reference/
 ---
-<h2>Javascript Figure Reference</h2>
+<h2>JavaScript Figure Reference</h2>
 
 <details>
     <summary>How are Plotly attributes organized?</summary>


### PR DESCRIPTION
The purpose of this PR is to change `plotly.js` to `JavaScript` in the navigation. 