### PR TITLE
Add transforms to full reference

### DIFF
--- a/_data/plotschema.json
+++ b/_data/plotschema.json
@@ -2233,14 +2233,9 @@
           "description": "Sets the calendar system to use with `y` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -4193,14 +4188,9 @@
           "description": "Sets the calendar system to use with `y` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -5901,14 +5891,9 @@
           "description": "Sets the calendar system to use with `y` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -6735,14 +6720,9 @@
           "description": "Determines whether or not the sectors are reordered from largest to smallest."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -7892,14 +7872,9 @@
           "description": "Sets the calendar system to use with `y` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -8854,14 +8829,9 @@
           "description": "Transposes the z data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -10123,14 +10093,9 @@
           "description": "Sets the calendar system to use with `y` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -11788,14 +11753,9 @@
           "description": "Sets the calendar system to use with `y` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -12849,14 +12809,9 @@
           "description": "Sets the method by which the span in data space where the density function will be computed. *soft* means the span goes from the sample's minimum value minus two bandwidths to the sample's maximum value plus two bandwidths. *hard* means the span goes from the sample's minimum to its maximum value. For custom span settings, use mode *manual* and fill in the `span` attribute."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -14454,14 +14409,9 @@
           "description": "Sets the calendar system to use with `y` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -15627,14 +15577,9 @@
           "description": "Sets the calendar system to use with `y` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -16927,14 +16872,9 @@
           "description": "Sets the calendar system to use with `y` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -17450,14 +17390,9 @@
           "description": "Sets the calendar system to use with `x` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -17942,14 +17877,9 @@
           "description": "Sets the calendar system to use with `x` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -18809,14 +18739,9 @@
           "role": "object"
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -20237,14 +20162,9 @@
           }
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -20949,14 +20869,9 @@
           "description": "If there are multiple funnelareas that should be sized according to their totals, link them by providing a non-empty group id here shared by every trace in the same group."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -21861,14 +21776,9 @@
           "role": "object"
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -24196,14 +24106,9 @@
           "description": "Sets the calendar system to use with `z` date data."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -33225,14 +33130,9 @@
           "editType": "calc"
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -34217,14 +34117,9 @@
           "editType": "calc"
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -35391,14 +35286,9 @@
           }
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -36385,14 +36275,9 @@
           }
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -37318,14 +37203,9 @@
           }
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -39053,14 +38933,9 @@
           "description": "Do the hover effects highlight individual points (markers or line points) or do they highlight filled regions? If the fill is *toself* or *tonext* and there are no markers or text, then the default is *fills*, otherwise it is *points*."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -40726,14 +40601,9 @@
           }
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -41926,14 +41796,9 @@
           }
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -43666,14 +43531,9 @@
           "description": "The number each triplet should sum to, if only two of `a`, `b`, and `c` are provided. This overrides `ternary<i>.sum` to normalize this specific trace, but does not affect the values displayed on the axes. 0 (or missing) means to use ternary<i>.sum"
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -44300,14 +44160,9 @@
           "description": "Sets the number of rendered sunburst rings from any given `level`. Set `maxdepth` to *-1* to render all the levels in the hierarchy."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -46775,14 +46630,9 @@
           }
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -47822,14 +47672,9 @@
           "role": "object"
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -48790,14 +48635,9 @@
           "role": "object"
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -52020,14 +51860,9 @@
           "description": "Do the hover effects highlight individual points (markers or line points) or do they highlight filled regions? If the fill is *toself* or *tonext* and there are no markers or text, then the default is *fills*, otherwise it is *points*."
         },
         "transforms": {
-          "items": {
-            "transform": {
-              "editType": "calc",
-              "description": "An array of operations that manipulate the trace data, for example filtering or sorting the data arrays.",
-              "role": "object"
-            }
-          },
-          "role": "object"
+          "items": true,
+          "valType": "info_array",
+          "role": "polymorphic_array"
         },
         "uirevision": {
           "valType": "any",
@@ -64668,297 +64503,305 @@
   },
   "transforms": {
     "aggregate": {
-      "attributes": {
-        "enabled": {
-          "valType": "boolean",
-          "dflt": true,
-          "role": "info",
-          "editType": "calc",
-          "description": "Determines whether this aggregate transform is enabled or disabled."
-        },
-        "groups": {
-          "valType": "string",
-          "strict": true,
-          "noBlank": true,
-          "arrayOk": true,
-          "dflt": "x",
-          "role": "info",
-          "editType": "calc",
-          "description": "Sets the grouping target to which the aggregation is applied. Data points with matching group values will be coalesced into one point, using the supplied aggregation functions to reduce data in other data arrays. If a string, `groups` is assumed to be a reference to a data array in the parent trace object. To aggregate by nested variables, use *.* to access them. For example, set `groups` to *marker.color* to aggregate about the marker color array. If an array, `groups` is itself the data array by which we aggregate."
-        },
-        "aggregations": {
-          "items": {
-            "aggregation": {
-              "target": {
-                "valType": "string",
-                "role": "info",
-                "editType": "calc",
-                "description": "A reference to the data array in the parent trace to aggregate. To aggregate by nested variables, use *.* to access them. For example, set `groups` to *marker.color* to aggregate over the marker color array. The referenced array must already exist, unless `func` is *count*, and each array may only be referenced once."
-              },
-              "func": {
-                "valType": "enumerated",
-                "values": [
-                  "count",
-                  "sum",
-                  "avg",
-                  "median",
-                  "mode",
-                  "rms",
-                  "stddev",
-                  "min",
-                  "max",
-                  "first",
-                  "last",
-                  "change",
-                  "range"
-                ],
-                "dflt": "first",
-                "role": "info",
-                "editType": "calc",
-                "description": "Sets the aggregation function. All values from the linked `target`, corresponding to the same value in the `groups` array, are collected and reduced by this function. *count* is simply the number of values in the `groups` array, so does not even require the linked array to exist. *first* (*last*) is just the first (last) linked value. Invalid values are ignored, so for example in *avg* they do not contribute to either the numerator or the denominator. Any data type (numeric, date, category) may be aggregated with any function, even though in certain cases it is unlikely to make sense, for example a sum of dates or average of categories. *median* will return the average of the two central values if there is an even count. *mode* will return the first value to reach the maximum count, in case of a tie. *change* will return the difference between the first and last linked values. *range* will return the difference between the min and max linked values."
-              },
-              "funcmode": {
-                "valType": "enumerated",
-                "values": [
-                  "sample",
-                  "population"
-                ],
-                "dflt": "sample",
-                "role": "info",
-                "editType": "calc",
-                "description": "*stddev* supports two formula variants: *sample* (normalize by N-1) and *population* (normalize by N)."
-              },
-              "enabled": {
-                "valType": "boolean",
-                "dflt": true,
-                "role": "info",
-                "editType": "calc",
-                "description": "Determines whether this aggregation function is enabled or disabled."
-              },
-              "editType": "calc",
-              "role": "object"
-            }
-          },
-          "role": "object"
-        },
+      "type": {
+        "valType": "\"aggregate\""
+      },
+      "enabled": {
+        "valType": "boolean",
+        "dflt": true,
+        "role": "info",
         "editType": "calc",
-        "groupssrc": {
-          "valType": "string",
-          "role": "info",
-          "description": "Sets the source reference on plot.ly for  groups .",
-          "editType": "none"
-        }
-      }
+        "description": "Determines whether this aggregate transform is enabled or disabled."
+      },
+      "groups": {
+        "valType": "string",
+        "strict": true,
+        "noBlank": true,
+        "arrayOk": true,
+        "dflt": "x",
+        "role": "info",
+        "editType": "calc",
+        "description": "Sets the grouping target to which the aggregation is applied. Data points with matching group values will be coalesced into one point, using the supplied aggregation functions to reduce data in other data arrays. If a string, `groups` is assumed to be a reference to a data array in the parent trace object. To aggregate by nested variables, use *.* to access them. For example, set `groups` to *marker.color* to aggregate about the marker color array. If an array, `groups` is itself the data array by which we aggregate."
+      },
+      "aggregations": {
+        "items": {
+          "aggregation": {
+            "target": {
+              "valType": "string",
+              "role": "info",
+              "editType": "calc",
+              "description": "A reference to the data array in the parent trace to aggregate. To aggregate by nested variables, use *.* to access them. For example, set `groups` to *marker.color* to aggregate over the marker color array. The referenced array must already exist, unless `func` is *count*, and each array may only be referenced once."
+            },
+            "func": {
+              "valType": "enumerated",
+              "values": [
+                "count",
+                "sum",
+                "avg",
+                "median",
+                "mode",
+                "rms",
+                "stddev",
+                "min",
+                "max",
+                "first",
+                "last",
+                "change",
+                "range"
+              ],
+              "dflt": "first",
+              "role": "info",
+              "editType": "calc",
+              "description": "Sets the aggregation function. All values from the linked `target`, corresponding to the same value in the `groups` array, are collected and reduced by this function. *count* is simply the number of values in the `groups` array, so does not even require the linked array to exist. *first* (*last*) is just the first (last) linked value. Invalid values are ignored, so for example in *avg* they do not contribute to either the numerator or the denominator. Any data type (numeric, date, category) may be aggregated with any function, even though in certain cases it is unlikely to make sense, for example a sum of dates or average of categories. *median* will return the average of the two central values if there is an even count. *mode* will return the first value to reach the maximum count, in case of a tie. *change* will return the difference between the first and last linked values. *range* will return the difference between the min and max linked values."
+            },
+            "funcmode": {
+              "valType": "enumerated",
+              "values": [
+                "sample",
+                "population"
+              ],
+              "dflt": "sample",
+              "role": "info",
+              "editType": "calc",
+              "description": "*stddev* supports two formula variants: *sample* (normalize by N-1) and *population* (normalize by N)."
+            },
+            "enabled": {
+              "valType": "boolean",
+              "dflt": true,
+              "role": "info",
+              "editType": "calc",
+              "description": "Determines whether this aggregation function is enabled or disabled."
+            },
+            "editType": "calc",
+            "role": "object"
+          }
+        },
+        "role": "object"
+      },
+      "editType": "calc",
+      "groupssrc": {
+        "valType": "string",
+        "role": "info",
+        "description": "Sets the source reference on plot.ly for  groups .",
+        "editType": "none"
+      },
+      "role": "object"
     },
     "filter": {
-      "attributes": {
-        "enabled": {
-          "valType": "boolean",
-          "dflt": true,
-          "role": "info",
-          "editType": "calc",
-          "description": "Determines whether this filter transform is enabled or disabled."
-        },
-        "target": {
-          "valType": "string",
-          "strict": true,
-          "noBlank": true,
-          "arrayOk": true,
-          "dflt": "x",
-          "role": "info",
-          "editType": "calc",
-          "description": "Sets the filter target by which the filter is applied. If a string, `target` is assumed to be a reference to a data array in the parent trace object. To filter about nested variables, use *.* to access them. For example, set `target` to *marker.color* to filter about the marker color array. If an array, `target` is then the data array by which the filter is applied."
-        },
-        "operation": {
-          "valType": "enumerated",
-          "values": [
-            "=",
-            "!=",
-            "<",
-            ">=",
-            ">",
-            "<=",
-            "[]",
-            "()",
-            "[)",
-            "(]",
-            "][",
-            ")(",
-            "](",
-            ")[",
-            "{}",
-            "}{"
-          ],
-          "dflt": "=",
-          "role": "info",
-          "editType": "calc",
-          "description": "Sets the filter operation. *=* keeps items equal to `value` *!=* keeps items not equal to `value` *<* keeps items less than `value` *<=* keeps items less than or equal to `value` *>* keeps items greater than `value` *>=* keeps items greater than or equal to `value` *[]* keeps items inside `value[0]` to `value[1]` including both bounds *()* keeps items inside `value[0]` to `value[1]` excluding both bounds *[)* keeps items inside `value[0]` to `value[1]` including `value[0]` but excluding `value[1] *(]* keeps items inside `value[0]` to `value[1]` excluding `value[0]` but including `value[1] *][* keeps items outside `value[0]` to `value[1]` and equal to both bounds *)(* keeps items outside `value[0]` to `value[1]` *](* keeps items outside `value[0]` to `value[1]` and equal to `value[0]` *)[* keeps items outside `value[0]` to `value[1]` and equal to `value[1]` *{}* keeps items present in a set of values *}{* keeps items not present in a set of values"
-        },
-        "value": {
-          "valType": "any",
-          "dflt": 0,
-          "role": "info",
-          "editType": "calc",
-          "description": "Sets the value or values by which to filter. Values are expected to be in the same type as the data linked to `target`. When `operation` is set to one of the comparison values (=,!=,<,>=,>,<=) `value` is expected to be a number or a string. When `operation` is set to one of the interval values ([],(),[),(],][,)(,](,)[) `value` is expected to be 2-item array where the first item is the lower bound and the second item is the upper bound. When `operation`, is set to one of the set values ({},}{) `value` is expected to be an array with as many items as the desired set elements."
-        },
-        "preservegaps": {
-          "valType": "boolean",
-          "dflt": false,
-          "role": "info",
-          "editType": "calc",
-          "description": "Determines whether or not gaps in data arrays produced by the filter operation are preserved. Setting this to *true* might be useful when plotting a line chart with `connectgaps` set to *false*."
-        },
+      "type": {
+        "valtype": "\"filter\""
+      },
+      "enabled": {
+        "valType": "boolean",
+        "dflt": true,
+        "role": "info",
         "editType": "calc",
-        "valuecalendar": {
-          "valType": "enumerated",
-          "values": [
-            "gregorian",
-            "chinese",
-            "coptic",
-            "discworld",
-            "ethiopian",
-            "hebrew",
-            "islamic",
-            "julian",
-            "mayan",
-            "nanakshahi",
-            "nepali",
-            "persian",
-            "jalali",
-            "taiwan",
-            "thai",
-            "ummalqura"
-          ],
-          "role": "info",
-          "editType": "calc",
-          "dflt": "gregorian",
-          "description": "Sets the calendar system to use for `value`, if it is a date."
-        },
-        "targetcalendar": {
-          "valType": "enumerated",
-          "values": [
-            "gregorian",
-            "chinese",
-            "coptic",
-            "discworld",
-            "ethiopian",
-            "hebrew",
-            "islamic",
-            "julian",
-            "mayan",
-            "nanakshahi",
-            "nepali",
-            "persian",
-            "jalali",
-            "taiwan",
-            "thai",
-            "ummalqura"
-          ],
-          "role": "info",
-          "editType": "calc",
-          "dflt": "gregorian",
-          "description": "Sets the calendar system to use for `target`, if it is an array of dates. If `target` is a string (eg *x*) we use the corresponding trace attribute (eg `xcalendar`) if it exists, even if `targetcalendar` is provided."
-        },
-        "targetsrc": {
-          "valType": "string",
-          "role": "info",
-          "description": "Sets the source reference on plot.ly for  target .",
-          "editType": "none"
-        }
-      }
+        "description": "Determines whether this filter transform is enabled or disabled."
+      },
+      "target": {
+        "valType": "string",
+        "strict": true,
+        "noBlank": true,
+        "arrayOk": true,
+        "dflt": "x",
+        "role": "info",
+        "editType": "calc",
+        "description": "Sets the filter target by which the filter is applied. If a string, `target` is assumed to be a reference to a data array in the parent trace object. To filter about nested variables, use *.* to access them. For example, set `target` to *marker.color* to filter about the marker color array. If an array, `target` is then the data array by which the filter is applied."
+      },
+      "operation": {
+        "valType": "enumerated",
+        "values": [
+          "=",
+          "!=",
+          "<",
+          ">=",
+          ">",
+          "<=",
+          "[]",
+          "()",
+          "[)",
+          "(]",
+          "][",
+          ")(",
+          "](",
+          ")[",
+          "{}",
+          "}{"
+        ],
+        "dflt": "=",
+        "role": "info",
+        "editType": "calc",
+        "description": "Sets the filter operation.\n*=* keeps items equal to `value`\n*!=* keeps items not equal to `value`\n*<* keeps items less than `value`\n*<=* keeps items less than or equal to `value`\n*>* keeps items greater than `value`\n*>=* keeps items greater than or equal to `value`\n*[]* keeps items inside `value[0]` to `value[1]` including both bounds\n*()* keeps items inside `value[0]` to `value[1]` excluding both bounds\n*[)* keeps items inside `value[0]` to `value[1]` including `value[0]` but excluding `value[1]\n*(]* keeps items inside `value[0]` to `value[1]` excluding `value[0]` but including `value[1]\n*][* keeps items outside `value[0]` to `value[1]` and equal to both bounds\n*)(* keeps items outside `value[0]` to `value[1]`\n*](* keeps items outside `value[0]` to `value[1]` and equal to `value[0]`\n*)[* keeps items outside `value[0]` to `value[1]` and equal to `value[1]`\n*{}* keeps items present in a set of values\n*}{* keeps items not present in a set of values"
+      },
+      "value": {
+        "valType": "any",
+        "dflt": 0,
+        "role": "info",
+        "editType": "calc",
+        "description": "Sets the value or values by which to filter. Values are expected to be in the same type as the data linked to `target`. When `operation` is set to one of the comparison values (=,!=,<,>=,>,<=) `value` is expected to be a number or a string. When `operation` is set to one of the interval values ([],(),[),(],][,)(,](,)[) `value` is expected to be 2-item array where the first item is the lower bound and the second item is the upper bound. When `operation`, is set to one of the set values ({},}{) `value` is expected to be an array with as many items as the desired set elements."
+      },
+      "preservegaps": {
+        "valType": "boolean",
+        "dflt": false,
+        "role": "info",
+        "editType": "calc",
+        "description": "Determines whether or not gaps in data arrays produced by the filter operation are preserved. Setting this to *true* might be useful when plotting a line chart with `connectgaps` set to *false*."
+      },
+      "editType": "calc",
+      "valuecalendar": {
+        "valType": "enumerated",
+        "values": [
+          "gregorian",
+          "chinese",
+          "coptic",
+          "discworld",
+          "ethiopian",
+          "hebrew",
+          "islamic",
+          "julian",
+          "mayan",
+          "nanakshahi",
+          "nepali",
+          "persian",
+          "jalali",
+          "taiwan",
+          "thai",
+          "ummalqura"
+        ],
+        "role": "info",
+        "editType": "calc",
+        "dflt": "gregorian",
+        "description": "Sets the calendar system to use for `value`, if it is a date."
+      },
+      "targetcalendar": {
+        "valType": "enumerated",
+        "values": [
+          "gregorian",
+          "chinese",
+          "coptic",
+          "discworld",
+          "ethiopian",
+          "hebrew",
+          "islamic",
+          "julian",
+          "mayan",
+          "nanakshahi",
+          "nepali",
+          "persian",
+          "jalali",
+          "taiwan",
+          "thai",
+          "ummalqura"
+        ],
+        "role": "info",
+        "editType": "calc",
+        "dflt": "gregorian",
+        "description": "Sets the calendar system to use for `target`, if it is an array of dates. If `target` is a string (eg *x*) we use the corresponding trace attribute (eg `xcalendar`) if it exists, even if `targetcalendar` is provided."
+      },
+      "targetsrc": {
+        "valType": "string",
+        "role": "info",
+        "description": "Sets the source reference on plot.ly for  target .",
+        "editType": "none"
+      },
+      "role": "object"
     },
     "groupby": {
-      "attributes": {
-        "enabled": {
-          "valType": "boolean",
-          "dflt": true,
-          "role": "info",
-          "editType": "calc",
-          "description": "Determines whether this group-by transform is enabled or disabled."
-        },
-        "groups": {
-          "valType": "data_array",
-          "dflt": [],
-          "role": "data",
-          "editType": "calc",
-          "description": "Sets the groups in which the trace data will be split. For example, with `x` set to *[1, 2, 3, 4]* and `groups` set to *['a', 'b', 'a', 'b']*, the groupby transform with split in one trace with `x` [1, 3] and one trace with `x` [2, 4]."
-        },
-        "nameformat": {
-          "valType": "string",
-          "role": "info",
-          "editType": "calc",
-          "description": "Pattern by which grouped traces are named. If only one trace is present, defaults to the group name (`\"%{group}\"`), otherwise defaults to the group name with trace name (`\"%{group} (%{trace})\"`). Available escape sequences are `%{group}`, which inserts the group name, and `%{trace}`, which inserts the trace name. If grouping GDP data by country when more than one trace is present, for example, the default \"%{group} (%{trace})\" would return \"Monaco (GDP per capita)\"."
-        },
-        "styles": {
-          "items": {
-            "style": {
-              "target": {
-                "valType": "string",
-                "role": "info",
-                "editType": "calc",
-                "description": "The group value which receives these styles."
-              },
-              "value": {
-                "valType": "any",
-                "role": "info",
-                "dflt": {},
-                "editType": "calc",
-                "description": "Sets each group styles. For example, with `groups` set to *['a', 'b', 'a', 'b']* and `styles` set to *[{target: 'a', value: { marker: { color: 'red' } }}] marker points in group *'a'* will be drawn in red.",
-                "_compareAsJSON": true
-              },
-              "editType": "calc",
-              "role": "object"
-            }
-          },
-          "role": "object"
-        },
+      "type": {
+        "valType": "\"groupby\""
+      },
+      "enabled": {
+        "valType": "boolean",
+        "dflt": true,
+        "role": "info",
         "editType": "calc",
-        "groupssrc": {
-          "valType": "string",
-          "role": "info",
-          "description": "Sets the source reference on plot.ly for  groups .",
-          "editType": "none"
-        }
-      }
+        "description": "Determines whether this group-by transform is enabled or disabled."
+      },
+      "groups": {
+        "valType": "data_array",
+        "dflt": [],
+        "role": "data",
+        "editType": "calc",
+        "description": "Sets the groups in which the trace data will be split. For example, with `x` set to *[1, 2, 3, 4]* and `groups` set to *['a', 'b', 'a', 'b']*, the groupby transform with split in one trace with `x` [1, 3] and one trace with `x` [2, 4]."
+      },
+      "nameformat": {
+        "valType": "string",
+        "role": "info",
+        "editType": "calc",
+        "description": "Pattern by which grouped traces are named. If only one trace is present, defaults to the group name (`\"%{group}\"`), otherwise defaults to the group name with trace name (`\"%{group} (%{trace})\"`). Available escape sequences are `%{group}`, which inserts the group name, and `%{trace}`, which inserts the trace name. If grouping GDP data by country when more than one trace is present, for example, the default \"%{group} (%{trace})\" would return \"Monaco (GDP per capita)\"."
+      },
+      "styles": {
+        "items": {
+          "style": {
+            "target": {
+              "valType": "string",
+              "role": "info",
+              "editType": "calc",
+              "description": "The group value which receives these styles."
+            },
+            "value": {
+              "valType": "any",
+              "role": "info",
+              "dflt": {},
+              "editType": "calc",
+              "description": "Sets each group styles. For example, with `groups` set to *['a', 'b', 'a', 'b']* and `styles` set to *[{target: 'a', value: { marker: { color: 'red' } }}] marker points in group *'a'* will be drawn in red.",
+              "_compareAsJSON": true
+            },
+            "editType": "calc",
+            "role": "object"
+          }
+        },
+        "role": "object"
+      },
+      "editType": "calc",
+      "groupssrc": {
+        "valType": "string",
+        "role": "info",
+        "description": "Sets the source reference on plot.ly for  groups .",
+        "editType": "none"
+      },
+      "role": "object"
     },
     "sort": {
-      "attributes": {
-        "enabled": {
-          "valType": "boolean",
-          "dflt": true,
-          "role": "info",
-          "editType": "calc",
-          "description": "Determines whether this sort transform is enabled or disabled."
-        },
-        "target": {
-          "valType": "string",
-          "strict": true,
-          "noBlank": true,
-          "arrayOk": true,
-          "dflt": "x",
-          "role": "info",
-          "editType": "calc",
-          "description": "Sets the target by which the sort transform is applied. If a string, *target* is assumed to be a reference to a data array in the parent trace object. To sort about nested variables, use *.* to access them. For example, set `target` to *marker.size* to sort about the marker size array. If an array, *target* is then the data array by which the sort transform is applied."
-        },
-        "order": {
-          "valType": "enumerated",
-          "values": [
-            "ascending",
-            "descending"
-          ],
-          "dflt": "ascending",
-          "role": "info",
-          "editType": "calc",
-          "description": "Sets the sort transform order."
-        },
+      "type": {
+        "valType": "\"sort\""
+      },
+      "enabled": {
+        "valType": "boolean",
+        "dflt": true,
+        "role": "info",
         "editType": "calc",
-        "targetsrc": {
-          "valType": "string",
-          "role": "info",
-          "description": "Sets the source reference on plot.ly for  target .",
-          "editType": "none"
-        }
-      }
+        "description": "Determines whether this sort transform is enabled or disabled."
+      },
+      "target": {
+        "valType": "string",
+        "strict": true,
+        "noBlank": true,
+        "arrayOk": true,
+        "dflt": "x",
+        "role": "info",
+        "editType": "calc",
+        "description": "Sets the target by which the sort transform is applied. If a string, *target* is assumed to be a reference to a data array in the parent trace object. To sort about nested variables, use *.* to access them. For example, set `target` to *marker.size* to sort about the marker size array. If an array, *target* is then the data array by which the sort transform is applied."
+      },
+      "order": {
+        "valType": "enumerated",
+        "values": [
+          "ascending",
+          "descending"
+        ],
+        "dflt": "ascending",
+        "role": "info",
+        "editType": "calc",
+        "description": "Sets the sort transform order."
+      },
+      "editType": "calc",
+      "targetsrc": {
+        "valType": "string",
+        "role": "info",
+        "description": "Sets the source reference on plot.ly for  target .",
+        "editType": "none"
+      },
+      "role": "object"
     }
   },
   "frames": {

--- a/_includes/posts/reference-block.html
+++ b/_includes/posts/reference-block.html
@@ -6,7 +6,7 @@
         and obj[0] != "description" and obj[0] != "_isLinkedToArray"
         and obj[0] != "items" and obj[0] != "uid"
         and obj[0] != "smith" and obj[0] != "_deprecated"
-        and obj[0] != "_isSubplotObj" and obj[0] != "transforms"
+        and obj[0] != "_isSubplotObj"
         and obj[0] != "editType" and obj[0] != "impliedEdits"%}
 
         {% if obj[0] == "type" and page.language == "python" and block == "data" %}
@@ -136,11 +136,14 @@
                 {% endif %}
             {% elsif obj[1].role == "object" %}
                 <br><em>Type:</em> {% raw %}{object}{% endraw %} containing one or more of the keys listed below.
+            {% elsif obj[1].role == "polymorphic_array" %}
+                 of {% raw %}{object}{% endraw %} where
+                each {% raw %}{object}{% endraw %} is one of the following object types
 
             {% endif %}
 
             {% if display_info and obj[1].description and obj[1].description!= "" %}
-                <p>{{ obj[1].description | escape }}</p>
+                <p>{{ obj[1].description | escape | newline_to_br }}</p>
             {% endif %}
 
             {% if obj[1].role == "object" %}
@@ -160,6 +163,17 @@
                 {% assign block = "nested" %}
                 {% include posts/reference-block.html parentlink=localparentlink block=block parentpath=localparentpath %}
                 {% assign attribute = parrentattribute %}
+            {% elsif obj[1].role == "polymorphic_array" %}
+                {% assign parentattribute = attribute %}
+                {% capture localparentlink %}{{include.parentlink}}-{{obj[0]}}{% endcapture %}
+                {% capture localparentpath %}{{include.parentpath}}-{{obj[0]}}{% endcapture %}
+                {% if obj[0] == "transforms" %}
+                    {% assign attribute = site.data.plotschema.transforms %}
+                    {% assign block = "nested" %}
+                    {% include posts/reference-block.html parentlink=localparentlink block=block parentpath=localparentpath %}
+
+                    {% assign attribute = parentattribute %}
+                {% endif %}
             {% endif %}
 
         </li>


### PR DESCRIPTION
Closes #1354

# Changes
## plotschema
- Add role `polymorphic_array` to `[trace].transforms` to denote that items in array are one of a few types of objects
- Remove `attributes` level from `transforms` and add role `object`
- Add line breaks between operators in `transforms.filter.operations`

## reference-block
- Remove `"transforms"` from list of keys to skip
- Add text describing polymorphic arrays
- Hard-code attribute to render `transforms`
- Use `newline_to_br` filter to process line breaks

# Note
The Algolia reference search should be updated before this is deployed