### PR TITLE
Add hovertemplate attr to trace

### DIFF
--- a/_posts/plotly_js/basic/bar/2018-02-27-bar-base.html
+++ b/_posts/plotly_js/basic/bar/2018-02-27-bar-base.html
@@ -14,7 +14,7 @@ var data = [
     x: ['2016','2017','2018'],
     y: [500,600,700],
     base: [-500,-600,-700],
-    hovertemplate: '%{base}<extra></extra>'
+    hovertemplate: '%{base}'
     marker: {
       color: 'red'
     },

--- a/_posts/plotly_js/basic/bar/2018-02-27-bar-base.html
+++ b/_posts/plotly_js/basic/bar/2018-02-27-bar-base.html
@@ -14,6 +14,7 @@ var data = [
     x: ['2016','2017','2018'],
     y: [500,600,700],
     base: [-500,-600,-700],
+    hovertemplate: '%{base}<extra></extra>'
     marker: {
       color: 'red'
     },


### PR DESCRIPTION
Added a hovertemplate attribute to the first trace so the number shown is equal to the base instead of 0 on hover. 'y' could be used in place of 'base' in the hovertemplate if user wants the number shown to be positive. Seems the user would want either 'y' or 'base' instead of 0 more often than not.