### PR TITLE
using variable for path so front-matter-ci.py can also run in py-docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
             git config --global user.name "Deployer"
             rm -rf _posts/python/html
             git clone -b built git@github.com:plotly/plotly.py-docs _posts/python/html
-            python front-matter-ci.py
+            python front-matter-ci.py _posts
             bundle exec jekyll build
             mkdir snapshots
             cd _site


### PR DESCRIPTION
The purpose of this PR is to modify `front-matter-ci.py` so that the path that contains the files to be checked is passed in as a variable rather than hard-coded. 

This is to enable this same script to be run in the `py-docs` repo, reducing duplication. 