### PR TITLE
Add title check to front-matter-ci.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
             git config --global user.name "Deployer"
             rm -rf _posts/python/html
             git clone -b built git@github.com:plotly/plotly.py-docs _posts/python/html
-            python front-matter-ci.py
+            python front-matter-ci.py _posts
             bundle exec jekyll build
             mkdir snapshots
             cd _site

--- a/_posts/plotly_js/README.md
+++ b/_posts/plotly_js/README.md
@@ -32,7 +32,6 @@ Our javascript tutorials are written in HTML files with embedded [codepen](http:
 2. `cd` into the folder you created and create an html index file labeled: `yyyy-mm-dd-chart_type_plotlyjs_index.html`. Copy the index file template below and replace with the necessary information pertaining to the doc you are creating.
   ```
   ---
-  title: JavaScript Graphing Library D3.js-based Add-Chart-Type-or-Topic | Examples | Plotly
   name: Add-Chart-Type-or-Topic
   permalink: javascript/add-chart-type-or-topic/
   description: How to make a D3.js-based add-chart-type-or-topic in javascript. Add an additional sentence summarizing chart-type or topic.

--- a/_posts/plotly_js/basic/treemap/2019-10-15-treemap_plotly_js_index.html
+++ b/_posts/plotly_js/basic/treemap/2019-10-15-treemap_plotly_js_index.html
@@ -1,5 +1,4 @@
 ---
-title: JavaScript Graphing Library D3.js-based Treemap Plots | Examples | Plotly
 name: Treemaps
 permalink: javascript/treemaps/
 description: How to make a D3.js-based treemap chart in javascript to visualize hierarchical data.

--- a/_posts/plotly_js/financial/2019-08-12-plotly_js-financial-index.html
+++ b/_posts/plotly_js/financial/2019-08-12-plotly_js-financial-index.html
@@ -1,6 +1,5 @@
 ---
 permalink: javascript/financial-charts/
-title: Plotly.js Financial Charts
 description: Plotly.js makes interactive, publication-quality graphs online. Examples of how to make financial charts.
 name: More Financial Charts
 layout: langindex

--- a/_posts/plotly_js/fundamentals/2019-09-11-plotly_js-fundamentals-index.html
+++ b/_posts/plotly_js/fundamentals/2019-09-11-plotly_js-fundamentals-index.html
@@ -1,6 +1,5 @@
 ---
 permalink: javascript/plotly-fundamentals/
-title: Plotly.js Fundamentals
 description: Plotly.js makes interactive, publication-quality graphs online. Tutorials and tips about fundamental features of Plotly JS
 name: More Fundamentals
 layout: langindex

--- a/_posts/plotly_js/statistical/2017-02-24-plotly_js-statistical-index.html
+++ b/_posts/plotly_js/statistical/2017-02-24-plotly_js-statistical-index.html
@@ -1,6 +1,5 @@
 ---
 permalink: javascript/statistical-charts/
-title: Plotly.js Statistical Charts
 description: Plotly.js makes interactive, publication-quality graphs online. Examples of how to make statistical charts such as boxplots and histograms.
 name: More Statistical Charts
 layout: langindex

--- a/_posts/plotly_js/subplot/2019-09-12-plotly_js-subplots-index.html
+++ b/_posts/plotly_js/subplot/2019-09-12-plotly_js-subplots-index.html
@@ -1,6 +1,5 @@
 ---
 permalink: javascript/subplot-charts/
-title: Plotly.js Subplots
 description: Plotly.js makes interactive, publication-quality graphs online. Examples of how to make subplots, insets, and multiple axes charts.
 name: More Subplots
 layout: langindex

--- a/_posts/python-v3/legacy/polar/2015-06-30-polar.html
+++ b/_posts/python-v3/legacy/polar/2015-06-30-polar.html
@@ -6,7 +6,6 @@ has_thumbnail: true
 thumbnail: thumbnail/polar-scatter.jpg
 layout: base
 language: python/v3
-title: Python Polar Charts | plotly
 display_as: legacy_charts
 has_thumbnail: true
 ipynb: ~notebook_demo/37

--- a/_posts/python-v3/legacy/scatterplot-matrix/2015-06-30-scatterplot-matrix.html
+++ b/_posts/python-v3/legacy/scatterplot-matrix/2015-06-30-scatterplot-matrix.html
@@ -7,7 +7,6 @@ thumbnail: thumbnail/scatterplot-matrix.jpg
 layout: base
 name: Scatterplot Matrix
 language: python/v3
-title: Python Scatterplot Matrix | plotly
 display_as: legacy_charts
 has_thumbnail: true
 ipynb: ~notebook_demo/27

--- a/_posts/python-v3/legacy/violin-plot/2015-06-30-violin-plot.html
+++ b/_posts/python-v3/legacy/violin-plot/2015-06-30-violin-plot.html
@@ -7,7 +7,6 @@ thumbnail: thumbnail/violin-plot.jpg
 layout: base
 name: Violin Plots
 language: python/v3
-title: Python Violin Plots | plotly
 display_as: legacy_charts
 has_thumbnail: true
 ipynb: ~notebook_demo/26

--- a/_posts/python/2019-07-03-3d-index.html
+++ b/_posts/python/2019-07-03-3d-index.html
@@ -1,7 +1,6 @@
 ---
 permalink: python/3d-charts/
 redirect_from: python/next/3d-charts/
-title: Python Graphing Library Basic Charts
 description: Plotly's Python graphing library makes interactive, publication-quality graphs online. Examples of how to make 3D charts.
 name: More 3D Charts
 layout: langindex

--- a/_posts/python/2019-07-03-basic-index.html
+++ b/_posts/python/2019-07-03-basic-index.html
@@ -1,7 +1,6 @@
 ---
 permalink: python/basic-charts/
 redirect_from: python/next/basic-charts/
-title: Python Graphing Library Basic Charts
 description: Plotly's Python graphing library makes interactive, publication-quality graphs online. Examples of how to make basic charts.
 name: More Basic Charts
 layout: langindex

--- a/_posts/python/2019-07-03-chart-events-index.html
+++ b/_posts/python/2019-07-03-chart-events-index.html
@@ -1,7 +1,6 @@
 ---
 permalink: python/chart-events/
 redirect_from: python/next/chart-events/
-title: Add Custom Interactivity with Jupyter Widgets
 description: All Plotly charts have click, hover and zoom events which can be accessed by go.FigureWidget using Jupyter Widgets.
 name: More FigureWidget Docs
 layout: langindex

--- a/_posts/python/2019-07-03-chart-studio-index.html
+++ b/_posts/python/2019-07-03-chart-studio-index.html
@@ -1,7 +1,6 @@
 ---
 permalink: python/chart-studio/
 redirect_from: python/next/chart-studio/
-title: Python Graphing Library with Chart Studio
 description: Plotly's Python graphing library makes interactive, publication-quality graphs online. Tutorials and tips about fundamental features of Plotly's python API.
 name: More Chart Studio Docs
 layout: langindex

--- a/_posts/python/2019-07-03-fundamentals-index.html
+++ b/_posts/python/2019-07-03-fundamentals-index.html
@@ -1,7 +1,6 @@
 ---
 permalink: python/plotly-fundamentals/
 redirect_from: python/next/plotly-fundamentals/
-title: Python Graphing Library Basic Charts
 description: Plotly's Python graphing library makes interactive, publication-quality graphs online. Tutorials and tips about fundamental features of Plotly's python API.
 name: More Plotly Fundamentals
 layout: langindex

--- a/_posts/python/2019-07-03-maps-index.html
+++ b/_posts/python/2019-07-03-maps-index.html
@@ -1,7 +1,6 @@
 ---
 permalink: python/maps/
 redirect_from: python/next/maps/
-title: Python Graphing Library Basic Charts
 description: Plotly's Python graphing library makes interactive, publication-quality maps online. Examples of how to make maps with Plotly and Mapbox.
 name: More Maps
 layout: langindex

--- a/_posts/python/2019-07-03-scientific-index.html
+++ b/_posts/python/2019-07-03-scientific-index.html
@@ -1,7 +1,6 @@
 ---
 permalink: python/scientific-charts/
 redirect_from: python/next/scientific-charts/
-title: Python Graphing Library Scientific Charts
 description: Plotly's Python graphing library makes interactive, publication-quality graphs online. Examples of how to make scientific charts such as contour plots, heatmaps, dendrograms, polar charts, and ternary plots.
 name: More Scientific Charts
 layout: langindex

--- a/_posts/python/2019-07-03-statistic-index.html
+++ b/_posts/python/2019-07-03-statistic-index.html
@@ -1,7 +1,6 @@
 ---
 permalink: python/statistical-charts/
 redirect_from: python/next/statistical-charts/
-title: Python Graphing Library Statistical Charts
 description: Plotly's Python graphing library makes interactive, publication-quality graphs online. Examples of how to make statistical charts such as box plots, histograms, and distrubution plots.
 name: More Statistical Charts
 layout: langindex

--- a/_posts/python/2019-07-03-subplots-index.html
+++ b/_posts/python/2019-07-03-subplots-index.html
@@ -1,7 +1,6 @@
 ---
 permalink: python/subplot-charts/
 redirect_from: python/next/subplot-charts/
-title: Python Graphing Library Basic Charts
 description: Plotly's Python graphing library makes interactive, publication-quality graphs online. Examples of how to make subplots, insets, and multiple axes charts.
 name: More Subplots
 layout: langindex

--- a/_posts/python/2019-09-13-financial-index.html
+++ b/_posts/python/2019-09-13-financial-index.html
@@ -1,6 +1,5 @@
 ---
 permalink: python/financial-charts/
-title: Python Graphing Library Financial Charts
 description: Plotly's Python graphing library makes interactive, publication-quality graphs online. Examples of how to make financial charts.
 name: More Financial Charts
 layout: langindex

--- a/_posts/python/chart-studio/2019-07-03-data-api.html
+++ b/_posts/python/chart-studio/2019-07-03-data-api.html
@@ -9,7 +9,6 @@ order: 5
 page_type: u-guide
 permalink: python/data-api/
 thumbnail: thumbnail/table.jpg
-title: Plotly Data API
 v4upgrade: True
 ---
 

--- a/_posts/python/chart-studio/2019-07-03-embedding-charts.html
+++ b/_posts/python/chart-studio/2019-07-03-embedding-charts.html
@@ -8,7 +8,6 @@ name: Embedding Graphs in HTML
 order: 6
 permalink: python/embedding-plotly-graphs-in-HTML/
 thumbnail: thumbnail/embed.jpg
-title: Python Embedding Graphs in HTML | Examples | Plotly
 v4upgrade: True
 ---
 

--- a/_posts/python/chart-studio/2019-07-03-get-requests.html
+++ b/_posts/python/chart-studio/2019-07-03-get-requests.html
@@ -8,7 +8,6 @@ name: Get Requests
 order: 8
 permalink: python/get-requests/
 thumbnail: thumbnail/spectral.jpg
-title: Python Get Requests | Examples | Plotly
 v4upgrade: True
 ---
 

--- a/_posts/python/chart-studio/2019-07-03-getting-started-with-chart-studio.html
+++ b/_posts/python/chart-studio/2019-07-03-getting-started-with-chart-studio.html
@@ -10,7 +10,6 @@ order: 0.1
 page_type: example_index
 permalink: python/getting-started-with-chart-studio/
 thumbnail: thumbnail/bubble.jpg
-title: Getting Started with Chart Studio for Python | plotly
 v4upgrade: True
 ---
 

--- a/_posts/python/chart-studio/2019-07-03-ipython-notebook-tutorial.html
+++ b/_posts/python/chart-studio/2019-07-03-ipython-notebook-tutorial.html
@@ -11,7 +11,6 @@ page_type: example_index
 permalink: python/ipython-notebook-tutorial/
 redirect_from: ipython-notebooks/ipython-notebook-tutorial/
 thumbnail: thumbnail/ipythonnb.jpg
-title: Jupyter Notebook Tutorial | plotly
 v4upgrade: True
 ---
 

--- a/_posts/python/chart-studio/2019-07-03-presentations-tool.html
+++ b/_posts/python/chart-studio/2019-07-03-presentations-tool.html
@@ -9,7 +9,6 @@ order: 0.6
 page_type: u-guide
 permalink: python/presentations-tool/
 thumbnail: thumbnail/pres_api.jpg
-title: Presentations Tool | plotly
 v4upgrade: True
 ---
 

--- a/_posts/python/chart-studio/2019-07-03-privacy.html
+++ b/_posts/python/chart-studio/2019-07-03-privacy.html
@@ -9,7 +9,6 @@ name: Privacy
 order: 2
 permalink: python/privacy/
 thumbnail: thumbnail/privacy.jpg
-title: Privacy | plotly
 v4upgrade: True
 ---
 

--- a/_posts/python/chart-studio/2019-07-03-proxy-configuration.html
+++ b/_posts/python/chart-studio/2019-07-03-proxy-configuration.html
@@ -8,7 +8,6 @@ name: Requests Behind Corporate Proxies
 order: 10
 permalink: python/proxy-configuration/
 thumbnail: thumbnail/net.jpg
-title: requests.exceptions.ConnectionError - Getting Around Corporate Proxies
 v4upgrade: True
 ---
 

--- a/_posts/python/chart-studio/data-api.md
+++ b/_posts/python/chart-studio/data-api.md
@@ -32,7 +32,6 @@ jupyter:
     page_type: u-guide
     permalink: python/data-api/
     thumbnail: thumbnail/table.jpg
-    title: Plotly Data API
     v4upgrade: true
 ---
 

--- a/_posts/python/chart-studio/embedding-charts.md
+++ b/_posts/python/chart-studio/embedding-charts.md
@@ -31,7 +31,6 @@ jupyter:
     order: 6
     permalink: python/embedding-plotly-graphs-in-HTML/
     thumbnail: thumbnail/embed.jpg
-    title: Python Embedding Graphs in HTML | Examples | Plotly
     v4upgrade: true
 ---
 

--- a/_posts/python/chart-studio/get-requests.md
+++ b/_posts/python/chart-studio/get-requests.md
@@ -31,7 +31,6 @@ jupyter:
     order: 8
     permalink: python/get-requests/
     thumbnail: thumbnail/spectral.jpg
-    title: Python Get Requests | Examples | Plotly
     v4upgrade: true
 ---
 

--- a/_posts/python/chart-studio/getting-started-with-chart-studio.md
+++ b/_posts/python/chart-studio/getting-started-with-chart-studio.md
@@ -33,7 +33,6 @@ jupyter:
     page_type: example_index
     permalink: python/getting-started-with-chart-studio/
     thumbnail: thumbnail/bubble.jpg
-    title: Getting Started with Chart Studio for Python | plotly
     v4upgrade: true
 ---
 

--- a/_posts/python/chart-studio/ipython-notebook-tutorial.md
+++ b/_posts/python/chart-studio/ipython-notebook-tutorial.md
@@ -31,7 +31,6 @@ jupyter:
     layout: base
     name: Jupyter Notebook Tutorial
     language: python
-    title: Jupyter Notebook Tutorial | plotly
     display_as: chart_studio
     has_thumbnail: true
     page_type: example_index

--- a/_posts/python/chart-studio/presentations-tool.md
+++ b/_posts/python/chart-studio/presentations-tool.md
@@ -31,7 +31,6 @@ jupyter:
     layout: base
     name: Presentations Tool
     language: python
-    title: Presentations Tool | plotly
     display_as: chart_studio
     has_thumbnail: true
     page_type: u-guide

--- a/_posts/python/chart-studio/privacy.md
+++ b/_posts/python/chart-studio/privacy.md
@@ -33,7 +33,6 @@ jupyter:
     order: 2
     permalink: python/privacy/
     thumbnail: thumbnail/privacy.jpg
-    title: Privacy | plotly
     v4upgrade: true
 ---
 

--- a/_posts/python/chart-studio/proxy-configuration.md
+++ b/_posts/python/chart-studio/proxy-configuration.md
@@ -23,7 +23,6 @@ jupyter:
     version: 3.6.5
   plotly:
     v4upgrade: true
-    title: requests.exceptions.ConnectionError - Getting Around Corporate Proxies
     name: Requests Behind Corporate Proxies
     permalink: python/proxy-configuration/
     description: How to configure Plotly's Python API to work with corporate proxies

--- a/_posts/r/README.md
+++ b/_posts/r/README.md
@@ -28,7 +28,6 @@
       - Include the following header (*replacing `your-tutorial-chart` with the type of chart you're creating in the tutorial.) :
       ```
       ---
-      title: Your-Tutorial-Chart in R | Examples | Plotly
       name: Your-Tutorial-Chart
       permalink: r/your-tutorial-chart/
       description: How to create your-tutorial-chart in R. Short description of your tutorial.

--- a/_posts/reference_pages/2015-08-19-plotly_js-reference.html
+++ b/_posts/reference_pages/2015-08-19-plotly_js-reference.html
@@ -4,7 +4,6 @@ layout: langindex
 page_type: reference
 language: plotly_js
 name: plotly.js chart attribute reference
-title: plotly.js chart attribute reference
 description: The extensive reference of plotly chart attributes for plotly.js.
 redirect_from: /javascript-graphing-library/reference/
 ---

--- a/_posts/reference_pages/2015-09-06-python-reference.html
+++ b/_posts/reference_pages/2015-09-06-python-reference.html
@@ -4,7 +4,6 @@ layout: langindex
 page_type: reference
 language: python
 name: Plotly | Python chart attribute reference
-title: Plotly | Python chart attribute reference
 description: The complete reference of Plotly chart attributes for Plotly's Python library.
 ---
 <h2>Python Figure Reference</h2>

--- a/_posts/reference_pages/2015-09-06-r-reference.html
+++ b/_posts/reference_pages/2015-09-06-r-reference.html
@@ -4,7 +4,6 @@ layout: langindex
 page_type: reference
 language: r
 name: plotly R chart attribute reference
-title: plotly R chart attribute reference
 description: The extensive reference of plotly chart attributes for plotly's R library.
 ---
 <h2>R Figure Reference</h2>

--- a/_posts/reference_pages/2015-09-09-matlab-reference.html
+++ b/_posts/reference_pages/2015-09-09-matlab-reference.html
@@ -4,7 +4,6 @@ layout: langindex
 page_type: reference
 language: matlab
 name: plotly chart attribute reference
-title: plotly chart attribute reference
 description: The extensive reference of plotly chart attributes for plotly's MATLAB library.
 ---
 <h2><code>matlab</code> figure reference</h2>

--- a/front-matter-ci.py
+++ b/front-matter-ci.py
@@ -24,6 +24,7 @@ for md_path in Path(path).glob("**/*.md"):
 
 #make sure that every post that is not a redirect has a name tag in the front matter
 noNamePaths = [];
+titlePaths = [];
 for post in allPosts:
     if len(post.metadata.keys()) > 0:
         meta = post.metadata
@@ -34,8 +35,16 @@ for post in allPosts:
                 continue
             else:
                 noNamePaths.append(post.metadata)
+        if "title" in meta:
+            titlePaths.append(post.metadata)
+
 
 if (len(noNamePaths) > 0):
     raise Exception("CI Check #1 Not Passed: post:'{}' is not a redirect but is missing a name frontmatter\n".format('\n'.join([str(item) for item in noNamePaths])))
 
 print("CI Check #1 Passed: All non-redirect posts have names!")
+
+if (len(titlePaths) > 0):
+    raise Exception("CI Check #2 Not Passed: post:'{}' has a title. Titles no longer needed!\n".format('\n'.join([str(item) for item in titlePaths])))
+
+print("CI Check #2 Passed: No posts have titles!")


### PR DESCRIPTION
The purpose of this PR is to ensure that no posts have a `title` front-matter since that is being autogenerated from the `name` front-matter now in the `seo.html` include. 