### PR TITLE
breadcrumb  for reference pages

### DIFF
--- a/_includes/layouts/breadcrumb.html
+++ b/_includes/layouts/breadcrumb.html
@@ -51,6 +51,14 @@
 
             {% endif %}
 
+            {% if page.layout != "langindex" %}
+            {% unless page.permalink == "/api/" %}
+                <li class="--breadcrumb-item">
+                    <span>{{page.name}}</span>
+                </li>
+            {% endunless %}
+            {% endif %}
+
             {% if page.page_type == "reference" %}
                 <li class="--breadcrumb-item">
                     <span>{{page.name}}</span>

--- a/_includes/layouts/breadcrumb.html
+++ b/_includes/layouts/breadcrumb.html
@@ -51,14 +51,6 @@
 
             {% endif %}
 
-            {% if page.layout != "langindex" %}
-            {% unless page.permalink == "/api/" %}
-                <li class="--breadcrumb-item">
-                    <span>{{page.name}}</span>
-                </li>
-            {% endunless %}
-            {% endif %}
-
             {% if page.page_type == "reference" %}
                 <li class="--breadcrumb-item">
                     <span>{{page.name}}</span>

--- a/_includes/layouts/breadcrumb.html
+++ b/_includes/layouts/breadcrumb.html
@@ -58,6 +58,12 @@
                 </li>
             {% endunless %}
             {% endif %}
+
+            {% if page.page_type == "reference" %}
+                <li class="--breadcrumb-item">
+                    <span>{{page.name}}</span>
+                </li>
+            {% endif %}
         </ul>
 
         <!--

--- a/_posts/reference_pages/2015-08-19-plotly_js-reference.html
+++ b/_posts/reference_pages/2015-08-19-plotly_js-reference.html
@@ -3,7 +3,7 @@ permalink: /javascript/reference/
 layout: langindex
 page_type: reference
 language: plotly_js
-name: plotly.js chart attribute reference
+name: Figure Reference
 title: plotly.js chart attribute reference
 description: The extensive reference of plotly chart attributes for plotly.js.
 redirect_from: /javascript-graphing-library/reference/

--- a/_posts/reference_pages/2015-09-06-python-reference.html
+++ b/_posts/reference_pages/2015-09-06-python-reference.html
@@ -3,7 +3,7 @@ permalink: /python/reference/
 layout: langindex
 page_type: reference
 language: python
-name: Plotly | Python chart attribute reference
+name: Figure Reference
 title: Plotly | Python chart attribute reference
 description: The complete reference of Plotly chart attributes for Plotly's Python library.
 ---

--- a/_posts/reference_pages/2015-09-06-r-reference.html
+++ b/_posts/reference_pages/2015-09-06-r-reference.html
@@ -3,7 +3,7 @@ permalink: /r/reference/
 layout: langindex
 page_type: reference
 language: r
-name: plotly R chart attribute reference
+name: Figure Reference
 title: plotly R chart attribute reference
 description: The extensive reference of plotly chart attributes for plotly's R library.
 ---

--- a/_posts/reference_pages/2015-09-09-matlab-reference.html
+++ b/_posts/reference_pages/2015-09-09-matlab-reference.html
@@ -3,7 +3,7 @@ permalink: /matlab/reference/
 layout: langindex
 page_type: reference
 language: matlab
-name: plotly chart attribute reference
+name: Figure Reference
 title: plotly chart attribute reference
 description: The extensive reference of plotly chart attributes for plotly's MATLAB library.
 ---

--- a/_posts/reference_pages/2016-06-03-plotly_js_function_ref.html
+++ b/_posts/reference_pages/2016-06-03-plotly_js_function_ref.html
@@ -1,5 +1,5 @@
 ---
-name: Plotly.js Function Reference
+name: Function Reference
 permalink: /javascript/plotlyjs-function-reference/
 description: Plotly.js function reference. How to create, update, and modify graphs drawn with Plotly's JavaScript Graphing Library.
 language: plotly_js


### PR DESCRIPTION
The purpose of this PR is to edit `breadcrumb.html` so that the reference pages have a visible breadcrumb. 

closes https://github.com/plotly/documentation/issues/1540