### PR TITLE
Remove has-thumbnail check from python basic index

### DIFF
--- a/_posts/python/2019-07-03-basic-index.html
+++ b/_posts/python/2019-07-03-basic-index.html
@@ -26,5 +26,5 @@ order: 8
 </header>
 
 
-		{% assign languagelistimg = site.posts | where: "language","python" | where: "display_as","basic" | where: "has_thumbnail",true | where: "layout","base" | sort: "order" %}
+		{% assign languagelistimg = site.posts | where: "language","python" | where: "display_as","basic" | where: "layout","base" | sort: "order" %}
         {% include posts/documentation_eg.html %}


### PR DESCRIPTION
The purpose of this PR is to fix the index page for basic posts by removing the has_thumbnail",true conditional.