### PR TITLE
refactor ci scripts

### DIFF
--- a/_posts/matlab/aircraft-pitch/2015-06-30-aircraft_pitch.html
+++ b/_posts/matlab/aircraft-pitch/2015-06-30-aircraft_pitch.html
@@ -1,5 +1,5 @@
 ---
-permalink: /matlab/aircraft-pitch-analysis-matlab-plotly
+permalink: /matlab/aircraft-pitch-analysis-matlab-plotly/
 description: MATLAB and Plotly analysis of aircraft pitch. Frequency domain methods for controller design.
 thumbnail: /images/static-image
 layout: base

--- a/_posts/plotly_js/maps/choropleth-mapbox/2019-08-16-choropleth_plotly_js_index.html
+++ b/_posts/plotly_js/maps/choropleth-mapbox/2019-08-16-choropleth_plotly_js_index.html
@@ -8,7 +8,6 @@ language: plotly_js
 page_type: example_index
 display_as: maps
 order: 3
-redirect_from: javascript-graphing-library/choropleth-mapbox/
 ---
 {% assign examples = site.posts | where:"language","plotly_js" | where:"suite","mapbox-county-choropleth" | sort: "order" %}
 {% include posts/auto_examples.html examples=examples %}

--- a/_posts/python-v3/report-generation/2015-06-30-email-reports.html
+++ b/_posts/python-v3/report-generation/2015-06-30-email-reports.html
@@ -1,5 +1,5 @@
 ---
-permalink: /python/v3/email-reports
+permalink: /python/v3/email-reports/
 description: How to email Plotly graphs in HTML reports with Python.
 name: Emailing Plotly Graphs with Python
 thumbnail: /images/static-image

--- a/_posts/python-v3/statistical/histogram/2015-06-30-histograms.html
+++ b/_posts/python-v3/statistical/histogram/2015-06-30-histograms.html
@@ -7,7 +7,6 @@ language: python/v3
 page_type: example_index
 display_as: statistical
 order: 3
-redirect_from: /python/histogram-tutorial/
 ipynb: ~notebook_demo/22
 layout: base
 ---

--- a/check-or-enforce-order.py
+++ b/check-or-enforce-order.py
@@ -21,15 +21,6 @@ categories = ["file_settings", "basic", "financial", "statistical", "scientific"
 def get_post(path):
     return fm.load(str(path))
 
-def get_all_posts(paths):
-    posts = []
-    for path in paths:
-        post = get_post(path)
-        front_matter = get_front_matter(post)
-        if validate_front_matter(front_matter):
-            posts.append({'path':path, 'order' : front_matter['order'], 'display_as' : front_matter['display_as']})
-    return posts
-
 def get_front_matter(post):
     if "jupyter" in post.metadata:
         return post["jupyter"]["plotly"]

--- a/check-or-enforce-order.py
+++ b/check-or-enforce-order.py
@@ -1,95 +1,120 @@
-import frontmatter
+import frontmatter as fm
 from pathlib import Path, PosixPath
 import sys
 
 # path here is intended to include only posts from a single language
+# _posts/r, _posts/plotly_js, _posts/python-v3, _posts/python in 'documentation'
+# build/html in 'plotly.py-docs'
 try:
     file_path = str(sys.argv[1])
 except:
     raise Exception("You need to specify a path!")
 
-# check to see if enforce flag was given
+# check to see if enforce flag was given at command line
 enforce = False
 if len(sys.argv) == 3:
     if sys.argv[2] == 'enforce':
         enforce = True
 
-# post families with these strings as "display_as" front-matter will be checked
 categories = ["file_settings", "basic", "financial", "statistical", "scientific", "maps", "3d_charts", "multiple_axes"]
 
-paths = []
-for suffix in ["md", "html"]:
-    paths += [x for x in Path(file_path).glob("**/*."+suffix)]
+def get_post(path):
+    return fm.load(str(path))
 
-def get_meta(post):
+def get_all_posts(paths):
+    posts = []
+    for path in paths:
+        post = get_post(path)
+        front_matter = get_front_matter(post)
+        if validate_front_matter(front_matter):
+            posts.append({'path':path, 'order' : front_matter['order'], 'display_as' : front_matter['display_as']})
+    return posts
+
+def get_front_matter(post):
     if "jupyter" in post.metadata:
         return post["jupyter"]["plotly"]
     else:
         return post.metadata
 
 # this function will mutate the front-matter to enforce a sequential order
-def enforceOrder(listToBeOrdered):
-    for index, post in enumerate(listToBeOrdered):
-        postToBeAltered = frontmatter.load(post['path'])
+def enforceOrder(list_to_be_ordered):
+    print(list_to_be_ordered)
+    for index, post in enumerate(list_to_be_ordered):
+        post_to_be_altered = fm.load(post)
         if file_path == "_posts/r": # accounts for the fact that sometimes there are both .md and .Rmd files
-            if post['path'][-3:] == ".md":
-                postToBeAltered.metadata['order'] = index+1
-                frontmatter.dump(postToBeAltered, post['path'])
-                rPath = post['path'][:-3] + '.Rmd'
+            if post[-3:] == ".md":
+                post_to_be_altered.metadata['order'] = index+1
+                fm.dump(post_to_be_altered, post)
+                rPath = post[:-3] + '.Rmd'
                 try: 
-                    rPostToBeAltered = frontmatter.load(rPath)
-                    rPostToBeAltered.metadata['order'] = index+1
-                    frontmatter.dump(rPostToBeAltered, rPath)
+                    rpost_to_be_altered = frontmatter.load(rPath)
+                    rpost_to_be_altered.metadata['order'] = index+1
+                    fm.dump(rpost_to_be_altered, rPath)
                 except:
                     continue
         elif file_path == "python": # accounts for the fact that this is also run in the plotly.py-docs repo
-            postToBeAltered.metadata["jupyter"]["plotly"]['order'] = (index+2 if index>=4 else index+1)
-            frontmatter.dump(postToBeAltered, post['path'])
+            post_to_be_altered.metadata["jupyter"]["plotly"]['order'] = (index+2 if index>=4 else index+1)
+            fm.dump(post_to_be_altered, post)
         else:        
-            postToBeAltered.metadata['order'] = index+1
-            frontmatter.dump(postToBeAltered, post['path'])
+            post_to_be_altered.metadata['order'] = index+1
+            fm.dump(post_to_be_altered, post)
 
-def checkConsecutive(listToBeChecked): 
+def is_consecutive(list_to_be_checked): 
     if file_path in ["python", "build/html"]:
-        listToBeChecked = listToBeChecked + [5]
-    return sorted(listToBeChecked) == list(range(1, len(listToBeChecked)+1))
+        list_to_be_checked = list_to_be_checked + [5]
+    print(sorted(list_to_be_checked))
+    return sorted(list_to_be_checked) == list(range(1, len(list_to_be_checked)+1))
 
-def main():
-    # 1. collect the current order of posts 
-    # 2. sort and check if sorted order is sequential
+def validate_front_matter(front_matter):
+    if len(front_matter.keys()) > 0:
+        if "display_as" in front_matter and "order" in front_matter:
+            if front_matter['display_as'] in categories:
+                return True
+        else:
+            return False
+    else:
+        return False
+
+def get_paths_and_orders_by_category():
+    posts_by_category = {category: dict(orders=[], paths=[]) for category in categories}
+    for suffix in ["md", "html"]:
+        for path in Path(file_path).glob("**/*."+suffix): 
+            if ".ipynb_checkpoints" not in str(file_path):
+                post = get_post(path)
+                front_matter = get_front_matter(post)
+                if "display_as" in front_matter:
+                    post_category = front_matter['display_as'] 
+                    if post_category in posts_by_category and validate_front_matter(front_matter):
+                        posts_by_category[post_category]["paths"].append(path)
+                        posts_by_category[post_category]["orders"].append(front_matter['order'])
+    return posts_by_category
+
+def check_order():
+    posts_by_category = get_paths_and_orders_by_category()
     for category in categories:
-        postFamily = []
-        #get all posts with frontmatter in md format
-        for md_path in paths:
-            post = frontmatter.load(str(md_path))
-            if ".ipynb_checkpoints" in str(md_path):
-                continue
-            metadata = get_meta(post)
-            if len(post.metadata.keys()) > 0:
-                if "display_as" in metadata:
-                    if metadata['display_as'] == category:
-                        postFamily.append({'path':str(md_path), 'order' : metadata['order']})
-        
-        sortedPostFamily = sorted(postFamily, key = lambda i: i['order'])
-
-        order = [ p['order'] for p in sortedPostFamily ]
-
-        print(order)
-
-        if not checkConsecutive(order):
+        print(category)
+        orders = posts_by_category[category]["orders"]
+        paths = posts_by_category[category]["paths"]
+        sorted_paths = [path for order, path in sorted(zip(orders, paths))]
+        if not is_consecutive(posts_by_category[category]["orders"]):
+            print("Order is not sequential! **CHECK NOT PASSED** in '{}' display_as!".format(category))
             if enforce is True:
-                print('Order Check Did Not Pass! ENFORCING CORRECT ORDER for {}'.format(category))
-                enforceOrder(sortedPostFamily)
+                print("ENFORCING CORRECT ORDER! for {}\n".format(category))
+                enforceOrder(sorted_paths)
             else:
                 arg = file_path if file_path != "build/html" else "python"
-                raise Exception("Order Check Failed in '{}' display_as! Run 'python check-or-enforce-order.py {} enforce' to resolve!".format(category, arg))
+                raise Exception("Order is not sequential! **CHECK NOT PASSED** in '{}' display_as! Run 'python check-or-enforce-order.py {} enforce' to resolve!".format(category, arg))
+        else:
+            print("*Check Passed!*\n")
 
-        print("Order Check Passed for {} display_as in {}!".format(category, file_path))
-        order = []
+print("**********************************************")
+print("Order of '{}' Before Enforcing!".format(file_path))
+print("**********************************************\n")
 
-main()
+check_order()
 
 if enforce is True:
-    print("******************Double Checking Order After Enforcing!***********************")
-    print("******************Double Checking Order After Enforcing!***********************")
-    main()
+    print("*******************************************")
+    print("Order of '{}' After Enforcing!".format(file_path))
+    print("*******************************************\n")
+    check_order()

--- a/check-or-enforce-order.py
+++ b/check-or-enforce-order.py
@@ -6,7 +6,7 @@ import sys
 # _posts/r, _posts/plotly_js, _posts/python-v3, _posts/python in 'documentation'
 # build/html in 'plotly.py-docs'
 try:
-    file_path = str(sys.argv[1])
+    folder_path = str(sys.argv[1])
 except:
     raise Exception("You need to specify a path!")
 
@@ -32,7 +32,7 @@ def enforceOrder(list_to_be_ordered):
     print(list_to_be_ordered)
     for index, post in enumerate(list_to_be_ordered):
         post_to_be_altered = fm.load(post)
-        if file_path == "_posts/r": # accounts for the fact that sometimes there are both .md and .Rmd files
+        if folder_path == "_posts/r": # accounts for the fact that sometimes there are both .md and .Rmd files
             if post[-3:] == ".md":
                 post_to_be_altered.metadata['order'] = index+1
                 fm.dump(post_to_be_altered, post)
@@ -43,7 +43,7 @@ def enforceOrder(list_to_be_ordered):
                     fm.dump(rpost_to_be_altered, rPath)
                 except:
                     continue
-        elif file_path == "python": # accounts for the fact that this is also run in the plotly.py-docs repo
+        elif folder_path == "python": # accounts for the fact that this is also run in the plotly.py-docs repo
             post_to_be_altered.metadata["jupyter"]["plotly"]['order'] = (index+2 if index>=4 else index+1)
             fm.dump(post_to_be_altered, post)
         else:        
@@ -51,7 +51,7 @@ def enforceOrder(list_to_be_ordered):
             fm.dump(post_to_be_altered, post)
 
 def is_consecutive(list_to_be_checked): 
-    if file_path in ["python", "build/html"]:
+    if folder_path in ["python", "build/html"]:
         list_to_be_checked = list_to_be_checked + [5]
     print(sorted(list_to_be_checked))
     return sorted(list_to_be_checked) == list(range(1, len(list_to_be_checked)+1))
@@ -69,8 +69,8 @@ def validate_front_matter(front_matter):
 def get_paths_and_orders_by_category():
     posts_by_category = {category: dict(orders=[], paths=[]) for category in categories}
     for suffix in ["md", "html"]:
-        for path in Path(file_path).glob("**/*."+suffix): 
-            if ".ipynb_checkpoints" not in str(file_path):
+        for path in Path(folder_path).glob("**/*."+suffix): 
+            if ".ipynb_checkpoints" not in str(path):
                 post = get_post(path)
                 front_matter = get_front_matter(post)
                 if "display_as" in front_matter:
@@ -93,19 +93,19 @@ def check_order():
                 print("ENFORCING CORRECT ORDER! for {}\n".format(category))
                 enforceOrder(sorted_paths)
             else:
-                arg = file_path if file_path != "build/html" else "python"
+                arg = folder_path if folder_path != "build/html" else "python"
                 raise Exception("Order is not sequential! **CHECK NOT PASSED** in '{}' display_as! Run 'python check-or-enforce-order.py {} enforce' to resolve!".format(category, arg))
         else:
             print("*Check Passed!*\n")
 
 print("**********************************************")
-print("Order of '{}' Before Enforcing!".format(file_path))
+print("Order of '{}' Before Enforcing!".format(folder_path))
 print("**********************************************\n")
 
 check_order()
 
 if enforce is True:
     print("*******************************************")
-    print("Order of '{}' After Enforcing!".format(file_path))
+    print("Order of '{}' After Enforcing!".format(folder_path))
     print("*******************************************\n")
     check_order()

--- a/front-matter-ci.py
+++ b/front-matter-ci.py
@@ -13,12 +13,14 @@ def ci_check(checkList, error_message):
     print("***********************************!")
     print("Checking... {}".format(error_message))
     if len(checkList) > 0:
-        print("Failed!")
+        print("NOT PASSED!\n")
         print("List of failed permalinks:")
-        print(checkList)
+        print("**{}**".format(checkList))
         print("\n")
+        return False
     else:
         print("Passed!")
+        return True
 
 paths = []
 allPosts = []
@@ -91,13 +93,15 @@ for post in allPermalinks:
         continue
     else:
         temp.append(post)
-        
-print("Begin CI Checks!\n")
-ci_check(postsWithNoName, "do all non-redirect posts have names?")
-ci_check(postsWithTitle, "do any posts have titles?")
-ci_check(indexOverflow, "are there posts with order > 5 and 'page_type: example_index'?")
-ci_check(duplicatePermalinks, "are there duplicate permalinks/redirect_froms?")
-ci_check(postsWithNoThumbnail, "does every post have a thumbnail?")
-ci_check(noTrailingSlash, "do any permalinks not end with a trailing slash?")
 
+print("Begin CI Checks!\n")
+passed_check_1 = ci_check(postsWithNoName, "do all non-redirect posts have names?")
+passed_check_2 = ci_check(postsWithTitle, "do any posts have titles?")
+passed_check_3 = ci_check(indexOverflow, "are there posts with order > 5 and 'page_type: example_index'?")
+passed_check_4 = ci_check(duplicatePermalinks, "are there duplicate permalinks/redirect_froms?")
+passed_check_5 = ci_check(postsWithNoThumbnail, "does every post have a thumbnail?")
+passed_check_6 = ci_check(noTrailingSlash, "do any permalinks not end with a trailing slash?")
 print("End CI Checks!\n")
+
+if not passed_check_1 or not passed_check_2 or not passed_check_3 or not passed_check_4 or not passed_check_5 or not passed_check_6:
+    raise Exception("***********CI Checks Not Passed! Check Error Messages!*********************")

--- a/front-matter-ci.py
+++ b/front-matter-ci.py
@@ -2,73 +2,102 @@ import frontmatter
 from pathlib import Path, PosixPath
 import sys
 
-# should be either '_posts' for this repo or 'build/html' for the py-docs repo
+# 'path' == '_posts' in 'documentation'
+# 'path' == 'build/html' in 'py-docs'
 try:
     path = str(sys.argv[1])
 except:
     raise Exception("You need to specify a path that contains the files with front matter.")
 
+def ci_check(checkList, error_message):
+    print("***********************************!")
+    print("Checking... {}".format(error_message))
+    if len(checkList) > 0:
+        print("Failed!")
+        print("List of failed permalinks:")
+        print(checkList)
+        print("\n")
+    else:
+        print("Passed!")
+
 paths = []
-for suffix in ["md", "hmtl"]:
+allPosts = []
+postsWithNoName = []
+postsWithTitle = []
+allPermalinks = []
+indexOverflow = []
+postsWithNoThumbnail = []
+temp = []
+duplicatePermalinks = []
+noTrailingSlash = []
+
+categories = ["file_settings", "basic", "financial", "statistical", "scientific", "maps", "3d_charts", "multiple_axes"]
+languages = ["python", "python/v3", "plotly_js", "r"]
+
+# collect all paths 
+for suffix in ["md", "html"]:
     paths += [x for x in Path(path).glob("**/*."+suffix)]
 
-# this will store the front matter for all posts in the given directory
-allPosts = [];
-
-#get all posts with frontmatter in md format
+# collect all posts
 for path in paths:
     post = frontmatter.load(str(path))
     if len(post.metadata.keys()) > 0:
         allPosts.append(post)
 
-#make sure that every post that is not a redirect has a name tag in the front matter
-noNamePaths = [];
-titlePaths = [];
-permalinks = [];
-
+# perform checks
 for post in allPosts:
-    if len(post.metadata.keys()) > 0:
-        meta = post.metadata
+    meta = post.metadata
+   
+    # ignore posts with 'jupyter' in front-matter
+    if "jupyter" in meta:
+        continue
 
-        #in case the front-matter format is different
-        if "jupyter" in meta:
-            continue
+    # Check #1 - do all non-redirect posts have names? 
+    if "name" not in meta and "redirect_to" not in meta:
+        postsWithNoName.append(post.metadata['permalink'])
 
-        # Check 1
-        if "name" not in meta and "redirect_to" not in meta:
-                noNamePaths.append(post.metadata)
+    # Check #2 - do any posts have titles?
+    if "title" in meta:
+        postsWithTitle.append(post.metadata['permalink'])
 
-        # Check 2
-        if "title" in meta:
-            titlePaths.append(post.metadata)
+    # Check #3 - are there duplicate permalinks/redirect_froms?
+    if "permalink" in meta and meta['permalink'] != '//plot.ly/products/dash/':
+        allPermalinks.append(meta['permalink'])
+    if "redirect_from" in meta:
+        allPermalinks.append(meta['redirect_from'])
+    
+    # Check #4 - are there posts with order > 5 and 'page_type: example_index'?
+    if "display_as" in meta and meta['display_as'] in categories:
+        if "language" in meta and meta['language'] in languages:
+            if "order" in meta and meta['order'] > 5:
+                if "page_type" in meta and meta['page_type'] == "example_index":
+                    indexOverflow.append(meta['permalink'])
+                        
+    # Check #5 - does every post have a thumbnail?
+    if "thumbnail" not in meta:
+        if "display_as" in meta and meta['display_as'] in categories:
+            if "language" in meta and meta['language'] in languages:
+                postsWithNoThumbnail.append(meta['permalink'])
+    
+    # Check #6 - do any permalinks not end with a trailing slash?
+    if "permalink" in meta:
+        if meta['permalink'][-1] != "/":
+            noTrailingSlash.append(meta['permalink'])
 
-        # Check 3 - ignor dash call outs
-        if "permalink" in meta and meta['permalink'] != '//plot.ly/products/dash/':
-            permalinks.append(meta['permalink'])
-        if "redirect_from" in meta:
-            permalinks.append(meta['redirect_from'])
 
-# Check 1
-if len(noNamePaths) > 0:
-    raise Exception("CI Check #1 Not Passed: post:\n'{}' is not a redirect but is missing a name frontmatter\n".format('\n'.join([str(item) for item in noNamePaths])))
-print("CI Check #1 Passed: All non-redirect posts have names!")
-
-# Check 2
-if len(titlePaths) > 0:
-    raise Exception("CI Check #2 Not Passed: post:\n'{}' has a title. Titles no longer needed!\n".format('\n'.join([str(item) for item in titlePaths])))
-print("CI Check #2 Passed: No posts have titles!")
-
-# Check 3
-temp = [];
-dupeLinks = [];
-
-for post in permalinks:
+for post in allPermalinks:
     if post in temp:
-        dupeLinks.append(post)
+        duplicatePermalinks.append(post)
         continue
     else:
         temp.append(post)
+        
+print("Begin CI Checks!\n")
+ci_check(postsWithNoName, "do all non-redirect posts have names?")
+ci_check(postsWithTitle, "do any posts have titles?")
+ci_check(indexOverflow, "are there posts with order > 5 and 'page_type: example_index'?")
+ci_check(duplicatePermalinks, "are there duplicate permalinks/redirect_froms?")
+ci_check(postsWithNoThumbnail, "does every post have a thumbnail?")
+ci_check(noTrailingSlash, "do any permalinks not end with a trailing slash?")
 
-if len(dupeLinks) > 0:
-    raise Exception("CI Check #3 Not Passed: Following permalinks:\n{} are duplicated!\n".format('\n'.join([str(item) for item in dupeLinks])))
-print("CI Check #3 Passed: No duplicate permalinks!")
+print("End CI Checks!\n")


### PR DESCRIPTION
The purpose of this PR is to refactor the scripts that run in CircleCI for performance and to add additional checks. 

- [x] fix typo in `front-matter-ci.py` => `hmtl` to `html`
- [x] add check to make sure that no post with `order` greater than 5 also has `page_type: example_index`
- [x] add check to make sure that all posts in Python, R, and JavaScript in the top 8 categories have a `thumbnail` front-matter.
- [x] refactor `check-or-enforce-order.py` to reduce time and space complexity of algorithm
- [x] add check to make sure permalinks have a trailing slash + fixup to posts missing trailing slash
- [x] fixup to posts with extraneous redirect_froms
- [x] only raise `Exception` after printing results of all tests in `front-matter-ci.py` and `check-or-enforce-order.py`
- [x] under_score variable names rather than camelCase