### PR TITLE
removing remaining references to has_thumbnail front-matter

### DIFF
--- a/_posts/plotly_js/basic/2017-02-24-plotly_js-basic-index.html
+++ b/_posts/plotly_js/basic/2017-02-24-plotly_js-basic-index.html
@@ -2,7 +2,6 @@
 description: Plotly.js makes interactive, publication-quality graphs online. Examples
   of how to make basic charts.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: langindex
 name: More Basic Charts

--- a/_posts/plotly_js/basic/WebGL/2018-08-07-webgl_plotlyjs_index.html
+++ b/_posts/plotly_js/basic/WebGL/2018-08-07-webgl_plotlyjs_index.html
@@ -2,7 +2,6 @@
 description: Implement WebGL for increased speed, improved interactivity, and the
   ability to plot even more data!
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: WebGL vs SVG

--- a/_posts/plotly_js/basic/area/2015-04-09-area_plotly_js_index.html
+++ b/_posts/plotly_js/basic/area/2015-04-09-area_plotly_js_index.html
@@ -2,7 +2,6 @@
 description: How to make a D3.js-based filled area plot in javascript. An area chart
   displays a solid color between the traces of a graph.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Filled Area Plots

--- a/_posts/plotly_js/basic/bar/2015-04-09-bar_plotly_js_index.html
+++ b/_posts/plotly_js/basic/bar/2015-04-09-bar_plotly_js_index.html
@@ -2,7 +2,6 @@
 description: How to make a D3.js-based bar chart in javascript. Seven examples of
   grouped, stacked, overlaid, and colored bar charts.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Bar Charts

--- a/_posts/plotly_js/basic/bubble/2015-04-09-bubble_plotly_js_index.html
+++ b/_posts/plotly_js/basic/bubble/2015-04-09-bubble_plotly_js_index.html
@@ -2,7 +2,6 @@
 description: How to make a D3.js-based bubble chart in javascript. Examples of scatter
   charts whose markers have variable color, size, and symbols.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Bubble Charts

--- a/_posts/plotly_js/basic/dot/2015-04-09-dot_plotly_js_index.html
+++ b/_posts/plotly_js/basic/dot/2015-04-09-dot_plotly_js_index.html
@@ -2,7 +2,6 @@
 description: How to make D3.js-based dot plots in JavaScript. Example of a styled,
   categorical dot plot.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Dot Plots

--- a/_posts/plotly_js/basic/horizontal-bar/2015-04-09-horizontal_bar_plotlyjs_index.html
+++ b/_posts/plotly_js/basic/horizontal-bar/2015-04-09-horizontal_bar_plotlyjs_index.html
@@ -1,7 +1,6 @@
 ---
 description: How to make a D3.js-based hortizontal bar chart in JavaScript.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Horizontal Bar Charts

--- a/_posts/plotly_js/basic/line-plots/2015-07-24-line-plots-index.html
+++ b/_posts/plotly_js/basic/line-plots/2015-07-24-line-plots-index.html
@@ -1,7 +1,6 @@
 ---
 description: How to make D3.js-based line charts in JavaScript.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Line Charts

--- a/_posts/plotly_js/basic/line_and_scatter/2015-04-09-line_and_scatter_plotly_js_index.html
+++ b/_posts/plotly_js/basic/line_and_scatter/2015-04-09-line_and_scatter_plotly_js_index.html
@@ -2,7 +2,6 @@
 description: How to make D3.js-based line and scatter plots in JavaScript. Examples
   of basic and colored line and scatter plots.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Scatter Plots

--- a/_posts/plotly_js/basic/mixed/2015-04-09-mixed_plotly_js_index.html
+++ b/_posts/plotly_js/basic/mixed/2015-04-09-mixed_plotly_js_index.html
@@ -2,7 +2,6 @@
 description: How to makes figures with D3.js-based mixed chart types in JavaScript.
   Examples of a contour plot with a scatter plot and a bar chart with a line chart.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Multiple Chart Types

--- a/_posts/plotly_js/basic/pie/2015-08-10-pie_plotly_js_index.html
+++ b/_posts/plotly_js/basic/pie/2015-08-10-pie_plotly_js_index.html
@@ -2,7 +2,6 @@
 description: How to graph D3.js-based pie charts in javascript with D3.js. Examples
   of pie charts, donut charts and pie chart subplots.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Pie Charts

--- a/_posts/plotly_js/basic/pointcloud/2017-06-15-plotlyjs-pointcloud-index.html
+++ b/_posts/plotly_js/basic/pointcloud/2017-06-15-plotlyjs-pointcloud-index.html
@@ -1,7 +1,6 @@
 ---
 description: How to make D3.js-based Point Cloud plots in Plotly.js.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Point Cloud

--- a/_posts/plotly_js/basic/sankey/2017-05-22-sankey_index.html
+++ b/_posts/plotly_js/basic/sankey/2017-05-22-sankey_index.html
@@ -1,7 +1,6 @@
 ---
 description: How to make D3.js-based sankey diagrams in Plotly.js.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Sankey Diagrams

--- a/_posts/plotly_js/basic/sunburst/2019-04-11-sunburst_plotly_js_index.html
+++ b/_posts/plotly_js/basic/sunburst/2019-04-11-sunburst_plotly_js_index.html
@@ -2,7 +2,6 @@
 description: How to make a D3.js-based sunburst chart in javascript. Visualize hierarchical
   data spanning outward radially from root to leaves.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Sunburst Charts

--- a/_posts/plotly_js/basic/table/2017-11-01-tables-plotly_js_index.html
+++ b/_posts/plotly_js/basic/table/2017-11-01-tables-plotly_js_index.html
@@ -1,7 +1,6 @@
 ---
 description: How to make a D3.js-based tables in javascript.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Tables

--- a/_posts/plotly_js/basic/treemap/2019-10-15-treemap_plotly_js_index.html
+++ b/_posts/plotly_js/basic/treemap/2019-10-15-treemap_plotly_js_index.html
@@ -2,7 +2,6 @@
 description: How to make a D3.js-based treemap chart in javascript to visualize hierarchical
   data.
 display_as: basic
-has_thumbnail: true
 language: plotly_js
 layout: base
 name: Treemaps

--- a/_posts/plotly_js/maps/bubble-maps/2015-07-11-bubble_maps_plotlyjs_index.html
+++ b/_posts/plotly_js/maps/bubble-maps/2015-07-11-bubble_maps_plotlyjs_index.html
@@ -5,7 +5,6 @@ description: How to make a D3.js-based bubble map in JavaScript. A bubble map ov
 layout: base
 thumbnail: thumbnail/bubble-map.jpg
 language: plotly_js
-has_thumbnail: true
 display_as: maps
 order: 6
 redirect_from: javascript-graphing-library/bubble-maps/

--- a/_posts/python-v3/3d/3d-filled-line/2015-06-30-3d-filled-line.html
+++ b/_posts/python-v3/3d/3d-filled-line/2015-06-30-3d-filled-line.html
@@ -7,7 +7,6 @@ layout: base
 name: 3D Filled Line Plots
 language: python/v3
 display_as: 3d_charts
-has_thumbnail: true
 order: 13
 ipynb: ~notebook_demo/65
 ---

--- a/_posts/python-v3/3d/3d-parametric/2015-06-30-3d-parametric.html
+++ b/_posts/python-v3/3d/3d-parametric/2015-06-30-3d-parametric.html
@@ -7,7 +7,6 @@ layout: base
 name: Parametric Plots
 language: python/v3
 display_as: 3d_charts
-has_thumbnail: true
 order: 17
 ipynb: ~notebook_demo/69
 ---

--- a/_posts/python-v3/3d/3d-ribbon/2015-06-30-ribbon.html
+++ b/_posts/python-v3/3d/3d-ribbon/2015-06-30-ribbon.html
@@ -7,7 +7,6 @@ layout: base
 name: Ribbon Plots
 language: python/v3
 display_as: 3d_charts
-has_thumbnail: true
 order: 12
 ipynb: ~notebook_demo/64
 ---

--- a/_posts/python-v3/3d/3d-wireframe/2015-06-30-3d-wireframe.html
+++ b/_posts/python-v3/3d/3d-wireframe/2015-06-30-3d-wireframe.html
@@ -7,7 +7,6 @@ layout: base
 name: 3D Wireframe Plots
 language: python/v3
 display_as: 3d_charts
-has_thumbnail: true
 order: 16
 ipynb: ~notebook_demo/68
 ---

--- a/_posts/python-v3/basic/WebGL/2015-06-30-webgl.html
+++ b/_posts/python-v3/basic/WebGL/2015-06-30-webgl.html
@@ -7,7 +7,6 @@ layout: base
 name: WebGL vs SVG
 language: python/v3
 display_as: basic
-has_thumbnail: true
 order: 18
 ipynb: ~notebook_demo/44
 ---

--- a/_posts/python-v3/fundamentals/images/2015-06-30-images.html
+++ b/_posts/python-v3/fundamentals/images/2015-06-30-images.html
@@ -7,7 +7,6 @@ layout: base
 name: Images
 language: python/v3
 display_as: file_settings
-has_thumbnail: true
 order: 21
 ipynb: ~notebook_demo/216
 ---

--- a/_posts/python-v3/fundamentals/ipython-vs-python/2015-06-30-ipython-vs-python.html
+++ b/_posts/python-v3/fundamentals/ipython-vs-python/2015-06-30-ipython-vs-python.html
@@ -6,7 +6,6 @@ layout: base
 name: IPython vs Python
 language: python/v3
 display_as: file_settings
-has_thumbnail: true
 order: 23
 ipynb: ~notebook_demo/17
 ---

--- a/_posts/python-v3/fundamentals/legends/2015-06-30-legend.html
+++ b/_posts/python-v3/fundamentals/legends/2015-06-30-legend.html
@@ -1,7 +1,6 @@
 ---
 permalink: python/v3/legend/
 description: How to configure and style the legend in Plotly with Python.
-has_thumbnail: true
 thumbnail: thumbnail/legends.gif
 name: Legends
 language: python/v3

--- a/_posts/python-v3/fundamentals/orca-management/2015-06-30-orca-management.html
+++ b/_posts/python-v3/fundamentals/orca-management/2015-06-30-orca-management.html
@@ -7,7 +7,6 @@ layout: base
 name: Orca Management
 language: python/v3
 display_as: file_settings
-has_thumbnail: true
 order: 6
 ipynb: ~notebook_demo/253
 ---

--- a/_posts/python-v3/scientific/log/2015-06-30-log-axes.html
+++ b/_posts/python-v3/scientific/log/2015-06-30-log-axes.html
@@ -6,7 +6,6 @@ layout: base
 name: Log Plots
 language: python/v3
 display_as: scientific
-has_thumbnail: true
 order: 7
 ipynb: ~notebook_demo/31
 ---

--- a/_posts/python-v3/scientific/quiver/2015-06-30-quiver.html
+++ b/_posts/python-v3/scientific/quiver/2015-06-30-quiver.html
@@ -6,7 +6,6 @@ layout: base
 name: Quiver Plots
 language: python/v3
 display_as: scientific
-has_thumbnail: true
 order: 14
 ipynb: ~notebook_demo/42
 ---

--- a/_posts/python-v3/scientific/streamline/2015-06-30-streamline.html
+++ b/_posts/python-v3/scientific/streamline/2015-06-30-streamline.html
@@ -6,7 +6,6 @@ layout: base
 name: Streamline Plots
 language: python/v3
 display_as: scientific
-has_thumbnail: true
 order: 15
 ipynb: ~notebook_demo/43
 ---

--- a/_posts/python-v3/statistical/tree-plot/2015-06-30-tree-plot.html
+++ b/_posts/python-v3/statistical/tree-plot/2015-06-30-tree-plot.html
@@ -6,7 +6,6 @@ layout: base
 name: Tree-plots
 language: python/v3
 display_as: statistical
-has_thumbnail: true
 order: 13
 ipynb: ~notebook_demo/28
 ---

--- a/_posts/python-v3/subplots/map-subplots/2015-06-30-map-subplots.html
+++ b/_posts/python-v3/subplots/map-subplots/2015-06-30-map-subplots.html
@@ -7,7 +7,6 @@ name: Map Subplots
 language: python/v3
 display_as: multiple_axes
 page_type: example_index
-has_thumbnail: true
 order: 3
 ipynb: ~notebook_demo/59
 ---

--- a/_posts/r/financial/2019-09-17-funnel-charts.md
+++ b/_posts/r/financial/2019-09-17-funnel-charts.md
@@ -1,7 +1,6 @@
 ---
 description: How to create a Funnel Chart in R with Plotly
 display_as: financial
-has_thumbnail: true
 language: r
 layout: base
 name: Funnel Charts

--- a/_posts/r/fundamentals/2015-04-09-static-image_r_index.md
+++ b/_posts/r/fundamentals/2015-04-09-static-image_r_index.md
@@ -2,7 +2,6 @@
 description: How to export plotly graphs as static images in R. Plotly supports png,
   svg, jpg, and pdf image export.
 display_as: file_settings
-has_thumbnail: true
 language: r
 layout: base
 name: Static Image Export

--- a/_posts/r/fundamentals/2015-07-30-privacy.md
+++ b/_posts/r/fundamentals/2015-07-30-privacy.md
@@ -1,7 +1,6 @@
 ---
 description: How to set the privacy settings of plotly graphs in R.
 display_as: file_settings
-has_thumbnail: true
 language: r
 layout: base
 name: Public vs Private Graphs

--- a/_posts/r/jupyter/2016-02-20-jupyter-notebook-r.html
+++ b/_posts/r/jupyter/2016-02-20-jupyter-notebook-r.html
@@ -1,7 +1,6 @@
 ---
 description: How to embed Plotly charts in Jupyter notebooks using R
 display_as: file_settings
-has_thumbnail: true
 language: r
 layout: base
 name: Plotly Charts in Jupyter notebooks using R

--- a/_posts/r/maps/2015-07-30-scatter-plot-maps.md
+++ b/_posts/r/maps/2015-07-30-scatter-plot-maps.md
@@ -2,7 +2,6 @@
 description: How to make scatter plots on maps in R. Scatter plots on maps highlight
   geographic areas and can be colored by value.
 display_as: maps
-has_thumbnail: true
 language: r
 layout: base
 name: Scatter Plots on Maps

--- a/_posts/r/maps/2017-02-27-scattermapbox.md
+++ b/_posts/r/maps/2017-02-27-scattermapbox.md
@@ -1,7 +1,6 @@
 ---
 description: How to create scattermapbox plots in R with Plotly.
 display_as: maps
-has_thumbnail: true
 language: r
 layout: base
 name: Scattermapbox

--- a/_posts/r/maps/2019-09-20-filled-area-on-mapbox.md
+++ b/_posts/r/maps/2019-09-20-filled-area-on-mapbox.md
@@ -1,7 +1,6 @@
 ---
 description: How to make an area on Map in R with plotly.
 display_as: maps
-has_thumbnail: true
 language: r
 layout: base
 name: Filled Area in Mapbox

--- a/_posts/r/maps/2019-09-20-mapbox-layers.md
+++ b/_posts/r/maps/2019-09-20-mapbox-layers.md
@@ -2,7 +2,6 @@
 description: How to make Mapbox maps in R with various base layers, with or without
   needing a Mapbox Access token.
 display_as: maps
-has_thumbnail: true
 language: r
 layout: base
 name: Mapbox Layers

--- a/_posts/r/maps/2019-09-27-lines-on-mapbox.md
+++ b/_posts/r/maps/2019-09-27-lines-on-mapbox.md
@@ -1,7 +1,6 @@
 ---
 description: How to draw a line on Map in R with plotly.
 display_as: maps
-has_thumbnail: true
 language: r
 layout: base
 name: Lines on Mapbox

--- a/_posts/r/scientific/2018-02-23-radar-charts.md
+++ b/_posts/r/scientific/2018-02-23-radar-charts.md
@@ -1,7 +1,6 @@
 ---
 description: How to create Radar Charts in R with Plotly.
 display_as: scientific
-has_thumbnail: true
 language: r
 layout: base
 name: Radar Charts


### PR DESCRIPTION
The purpose of this PR is to remove remaining references to `has_thumbnail` front-matter as it is no longer referred to in the build process. 