### PR TITLE
Fix typo in title standoff docs

### DIFF
--- a/_posts/plotly_js/fundamentals/axes/2019-11-04-title_standoff.html
+++ b/_posts/plotly_js/fundamentals/axes/2019-11-04-title_standoff.html
@@ -6,7 +6,7 @@ order: 3.5
 sitemap: false
 arrangement: horizontal
 markdown_content: |
-   THis example sets `standoff` attribute to cartesian axes to determine the distance between the tick labels and the axis title.
+   This example sets `standoff` attribute to cartesian axes to determine the distance between the tick labels and the axis title.
    Note that the axis title position is always constrained within the margins, so the actual standoff distance is always less than the set or default value.
    By setting standoff and turning [automargin](https://plot.ly/javascript/setting-graph-size/#automatically-adjust-margins) on, plotly.js will push the margins to fit the axis title at given standoff distance.
 ---


### PR DESCRIPTION
This PR fixes a simple typo in the axis title standoff documentation.