### PR TITLE
rendering map-animations example inline

### DIFF
--- a/_posts/plotly_js/animations/map-animations/2017-08-22-choropleth-animation.html
+++ b/_posts/plotly_js/animations/map-animations/2017-08-22-choropleth-animation.html
@@ -1,6 +1,5 @@
 ---
 name: Map Animations
-plot_url: https://codepen.io/plotly/embed/WqZOVG/?height=500&theme-id=15263&default-tab=result
 language: plotly_js
 suite: map-animations
 order: 1


### PR DESCRIPTION
closes https://github.com/plotly/documentation/issues/1483

The purpose of this PR is to render the correct chart for the `javascript/map-animations` example. 

Before:

<img width="1552" alt="Screen Shot 2020-01-06 at 12 13 14 PM" src="https://user-images.githubusercontent.com/1557650/71835781-66640700-3080-11ea-9b2a-bf30a218779a.png">

After:

<img width="1552" alt="Screen Shot 2020-01-06 at 12 13 18 PM" src="https://user-images.githubusercontent.com/1557650/71835815-81cf1200-3080-11ea-82c7-cbf5e3aa6b28.png">
