### PR TITLE
fix legend-inside by specifying xanchor to right

### DIFF
--- a/_posts/plotly_js/fundamentals/legends/2015-04-09-legend-inside.html
+++ b/_posts/plotly_js/fundamentals/legends/2015-04-09-legend-inside.html
@@ -21,6 +21,7 @@ var layout = {
   showlegend: true,
   legend: {
     x: 1,
+    xanchor: 'right',
     y: 1
   }
 };


### PR DESCRIPTION
Right now the "legend inside" example is broken:
![newplot (38)](https://user-images.githubusercontent.com/301546/71916723-9082fb00-314c-11ea-950f-8243970320cd.png)

This PR fixes it:
![newplot (39)](https://user-images.githubusercontent.com/301546/71916780-b27c7d80-314c-11ea-8a21-a539b0ae0069.png)
