### PR TITLE
update ci script

### DIFF
--- a/front-matter-ci.py
+++ b/front-matter-ci.py
@@ -81,7 +81,7 @@ def check_no_example_index_with_order_under_5(meta_to_check):
     failures = []
     for meta in meta_to_check:
         if meta["order"] < 5 and meta['page_type'] == "u-guide":
-            failures.append(meta)
+            failures.append(meta['permalink'])
     return "do any posts have order less than five but page_type: u-guide?", failures
 
 categories = [

--- a/front-matter-ci.py
+++ b/front-matter-ci.py
@@ -77,6 +77,12 @@ def check_noTrailingSlash(meta_to_check):
                 failures.append(meta["permalink"])
     return "do any permalinks not end with a trailing slash?", failures
 
+def check_no_example_index_with_order_under_5(meta_to_check):
+    failures = []
+    for meta in meta_to_check:
+        if meta["order"] < 5 and meta['page_type'] == "u-guide":
+            failures.append(meta)
+    return "do any posts have order less than five but page_type: u-guide?", failures
 
 categories = [
     "file_settings",


### PR DESCRIPTION
The purpose of this PR is to update the CI script so that it will highlight posts with `order` less than five but also have `page_type: u-guide`.  This combination will not cause the build to fail but will prevent the post from being on the language index. 

This PR will fail CI until https://github.com/plotly/plotly.py/pull/2115 is merged, as those posts currently fail this test. 