### PR TITLE
Inside text fixup

### DIFF
--- a/_posts/plotly_js/basic/pie/2020-01-14-inside-text-orientation.html
+++ b/_posts/plotly_js/basic/pie/2020-01-14-inside-text-orientation.html
@@ -6,7 +6,7 @@ order: 5
 sitemap: false
 arrangement: horizontal
 markdown_content: |
-  The `insidetextorientation` attribute controls the orientation of the text inside pie chart sectors. When set to 'auto', text may be oriented in any direction in order to be as big as possible in the middle of a sector. The 'horizontal' option orients text to be parallel with the bottom of the chart, and will make text smaller in order to achieve that goal. The 'radial' option orients text along the radius of the sector. The 'tangential' option orients text perpendicular to the radius of the sector.
+  The `insidetextorientation` attribute controls the orientation of the text inside chart sectors. When set to *auto*, text may be oriented in any direction in order to be as big as possible in the middle of a sector. The *horizontal* option orients text to be parallel with the bottom of the chart, and may make text smaller in order to achieve that goal. The *radial* option orients text along the radius of the sector. The *tangential* option orients text perpendicular to the radius of the sector.
 ---
 var data = [{
   type: "pie",

--- a/_posts/plotly_js/basic/pie/2020-01-14-inside-text-orientation.html
+++ b/_posts/plotly_js/basic/pie/2020-01-14-inside-text-orientation.html
@@ -1,12 +1,12 @@
 ---
-name: Control text orientation inside Pie slices
+name: Control Text Orientation Inside Pie Chart Sectors
 language: plotly_js
 suite: pie
 order: 5
 sitemap: false
 arrangement: horizontal
 markdown_content: |
-  The [insidetextorientation](https://plot.ly/javascript/reference/#pie-insidetextorientation) attribute controls the orientation of the texts inside slices. With 'auto' the texts may automatically be rotated to fit with the maximum size inside the slice. The other three options 'horizontal', 'radial', and 'tangential' forces text to be horizontal, radial, and tangential.
+  The `insidetextorientation` attribute controls the orientation of the text inside pie chart sectors. When set to 'auto', text may be oriented in any direction in order to be as big as possible in the middle of a sector. The 'horizontal' option orients text to be parallel with the bottom of the chart, and will make text smaller in order to achieve that goal. The 'radial' option orients text along the radius of the sector. The 'tangential' option orients text perpendicular to the radius of the sector.
 ---
 var data = [{
   type: "pie",
@@ -15,6 +15,7 @@ var data = [{
   textinfo: "label+percent",
   insidetextorientation: "radial"
 }]
+
 var layout = [{
   height: 700,
   width: 700

--- a/_posts/plotly_js/basic/sunburst/2020-01-14-inside-text-orientation.html
+++ b/_posts/plotly_js/basic/sunburst/2020-01-14-inside-text-orientation.html
@@ -1,29 +1,29 @@
 ---
-name: Control text orientation inside Sunburst slices
+name: Control Text Orientation Inside Sunburst Chart Sectors
 language: plotly_js
 suite: sunburst
 order: 6
 sitemap: false
 arrangement: horizontal
 markdown_content: |
-  The [insidetextorientation](https://plot.ly/javascript/reference/#sunburst-insidetextorientation) attribute controls the orientation of the texts inside chart sectors. When set to 'auto' the texts may automatically be rotated to fit with the maximum size inside a sector. The other three options 'horizontal', 'radial', and 'tangential' first try to orient text at the 3:00, 6:00, 9:00, and 12:00 hours. If there is no enough room, then the text would be positioned in the middle of the arc.
+  The `insidetextorientation` attribute controls the orientation of the text inside sunburst chart sectors. When set to 'auto', text may be oriented in any direction in order to be as big as possible in the middle of a sector. The 'horizontal' option orients text to be parallel with the bottom of the chart, and will make text smaller in order to achieve that goal. The 'radial' option orients text along the radius of the sector. The 'tangential' option orients text perpendicular to the radius of the sector.
 ---
 Plotly.d3.csv('https://raw.githubusercontent.com/plotly/datasets/master/coffee-flavors.csv', function(err, rows){
   function unpack(rows, key) {
   return rows.map(function(row) {return row[key]})
 }
 
-var data = [{
-      type: "sunburst",
-      maxdepth: 2,
-      ids: unpack(rows, 'ids'),
-      labels: unpack(rows, 'labels'),
-      parents: unpack(rows, 'parents'),
-      textposition: 'inside',
-      insidetextorientation: 'radial'
-}]
+  var data = [{
+        type: "sunburst",
+        maxdepth: 2,
+        ids: unpack(rows, 'ids'),
+        labels: unpack(rows, 'labels'),
+        parents: unpack(rows, 'parents'),
+        textposition: 'inside',
+        insidetextorientation: 'radial'
+  }]
 
-var layout = {margin: {l: 0, r: 0, b: 0, t:0}}
+  var layout = {margin: {l: 0, r: 0, b: 0, t:0}}
 
-Plotly.newPlot('myDiv', data, layout)
+  Plotly.newPlot('myDiv', data, layout)
 })

--- a/_posts/plotly_js/basic/sunburst/2020-01-14-inside-text-orientation.html
+++ b/_posts/plotly_js/basic/sunburst/2020-01-14-inside-text-orientation.html
@@ -6,7 +6,7 @@ order: 6
 sitemap: false
 arrangement: horizontal
 markdown_content: |
-  The `insidetextorientation` attribute controls the orientation of the text inside sunburst chart sectors. When set to 'auto', text may be oriented in any direction in order to be as big as possible in the middle of a sector. The 'horizontal' option orients text to be parallel with the bottom of the chart, and will make text smaller in order to achieve that goal. The 'radial' option orients text along the radius of the sector. The 'tangential' option orients text perpendicular to the radius of the sector.
+The `insidetextorientation` attribute controls the orientation of the text inside chart sectors. When set to *auto*, text may be oriented in any direction in order to be as big as possible in the middle of a sector. The *horizontal* option orients text to be parallel with the bottom of the chart, and may make text smaller in order to achieve that goal. The *radial* option orients text along the radius of the sector. The *tangential* option orients text perpendicular to the radius of the sector.
 ---
 Plotly.d3.csv('https://raw.githubusercontent.com/plotly/datasets/master/coffee-flavors.csv', function(err, rows){
   function unpack(rows, key) {

--- a/_posts/plotly_js/basic/sunburst/2020-01-14-inside-text-orientation.html
+++ b/_posts/plotly_js/basic/sunburst/2020-01-14-inside-text-orientation.html
@@ -6,7 +6,7 @@ order: 6
 sitemap: false
 arrangement: horizontal
 markdown_content: |
-The `insidetextorientation` attribute controls the orientation of the text inside chart sectors. When set to *auto*, text may be oriented in any direction in order to be as big as possible in the middle of a sector. The *horizontal* option orients text to be parallel with the bottom of the chart, and may make text smaller in order to achieve that goal. The *radial* option orients text along the radius of the sector. The *tangential* option orients text perpendicular to the radius of the sector.
+  The `insidetextorientation` attribute controls the orientation of the text inside chart sectors. When set to *auto*, text may be oriented in any direction in order to be as big as possible in the middle of a sector. The *horizontal* option orients text to be parallel with the bottom of the chart, and may make text smaller in order to achieve that goal. The *radial* option orients text along the radius of the sector. The *tangential* option orients text perpendicular to the radius of the sector.
 ---
 Plotly.d3.csv('https://raw.githubusercontent.com/plotly/datasets/master/coffee-flavors.csv', function(err, rows){
   function unpack(rows, key) {


### PR DESCRIPTION
This PR is to fixup the text description for the `insidetextorientation` attribute for pie and sunburst traces. 